### PR TITLE
8 ndfc vrf migrate to rest send and sender

### DIFF
--- a/examples/config_vrf_add.yaml
+++ b/examples/config_vrf_add.yaml
@@ -1,0 +1,6 @@
+config:
+  fabric_name: MyFabric
+  vrf_display_name: MyVrf
+  vrf_id: 50055
+  vrf_name: MyVrf
+  vrf_vlan_id: 2006

--- a/examples/vrf_add.py
+++ b/examples/vrf_add.py
@@ -1,58 +1,126 @@
 #!/usr/bin/env python3
 """
-Name: example_ndfc_vrf_add.py
-Description: Add a vrf to a fabric
+# Name
 
-NOTES:
+vrf_add.py
 
-1.  Set the following environment variables before running this script
-    (edit appropriately for your setup)
+# Description
 
-export PYTHONPATH=$PYTHONPATH:$HOME/repos/ndfc-python/lib:$HOME/repos/netbox-tools/lib
-export NDFC_PYTHON_CONFIG=$HOME/repos/ndfc-python/lib/ndfc_python/config/config.yml
+Add a vrf to a fabric
 
-Optional, to enable logging:
-export NDFC_LOGGING_CONFIG=$HOME/repos/ndfc-python/lib/ndfc_python/logging_config.json
+#Usage
 
-2. Edit the VRF values in the script below.
+Edit ``examples/config_vrf_add.yaml`` appropriately for your setup.
+
+```yaml
+config:
+  fabric_name: MyFabric
+  vrf_display_name: MyVrf
+  vrf_id: 50055
+  vrf_name: MyVrf
+  vrf_vlan_id: 2006
+```
+
+If you've set the standard ndfc-python Nexus Dashboard credentials
+environment variables (NDFC_DOMAIN, NDFC_IP4, NDFC_PASSWORD, NDFC_USERNAME)
+then you're good to go.
+
+```bash
+./vrf_add.py --config config_vrf_add.yaml
+```
+
+If you haven't set the standard ndfc-python Nexus Dashboard credentials
+environment variables, you can override them like so:
+
+```bash
+./vrf_add.py --config device_info_config.yaml --username admin --password MyPassword --domain local --ip4 10.1.1.2
 """
+import argparse
 import logging
 import sys
 
-from ndfc_python.log_v2 import Log
-from ndfc_python.ndfc import NDFC, NdfcRequestError
-from ndfc_python.ndfc_credentials import NdfcCredentials
-from ndfc_python.ndfc_vrf import NdfcVrf
+# We are using our local copy of log_v2.py which is modified to allow
+# console logging.  The copy in the DCNM Ansible Collection specifically
+# disallows console logging.
+from ndfc_python.ndfc_python_config import NdfcPythonConfig
+from ndfc_python.ndfc_python_logger import NdfcPythonLogger
+from ndfc_python.ndfc_python_sender import NdfcPythonSender
+from ndfc_python.parsers.parser_config import parser_config
+from ndfc_python.parsers.parser_controller_domain import parser_controller_domain
+from ndfc_python.parsers.parser_controller_ip4 import parser_controller_ip4
+from ndfc_python.parsers.parser_controller_password import parser_controller_password
+from ndfc_python.parsers.parser_controller_username import parser_controller_username
+from ndfc_python.parsers.parser_loglevel import parser_loglevel
+from ndfc_python.vrf_create import VrfCreate
+from plugins.module_utils.common.response_handler import ResponseHandler
+from plugins.module_utils.common.rest_send_v2 import RestSend
+from plugins.module_utils.common.results import Results
+
+
+def setup_parser() -> argparse.Namespace:
+    """
+    ### Summary
+
+    Setup script-specific parser
+
+    Returns:
+        argparse.Namespace
+    """
+    parser = argparse.ArgumentParser(
+        parents=[
+            parser_config,
+            parser_loglevel,
+            parser_controller_domain,
+            parser_controller_ip4,
+            parser_controller_password,
+            parser_controller_username,
+        ],
+        description="DESCRIPTION: Print the reachability status of a switch.",
+    )
+    return parser.parse_args()
+
+
+args = setup_parser()
+
+
+NdfcPythonLogger()
+log = logging.getLogger("ndfc_python.main")
+log.setLevel = args.loglevel
 
 try:
-    log = Log()
-    log.commit()
+    ndfc_sender = NdfcPythonSender()
+    ndfc_sender.args = args
+    ndfc_sender.commit()
 except ValueError as error:
-    msg = "Error while instantiating Log(). "
-    msg += f"Error detail: {error}"
-    print(msg)
+    msg = f"Exiting.  Error detail: {error}"
+    log.error(msg)
     sys.exit(1)
 
-log = logging.getLogger("ndfc_python.main")
+try:
+    ndfc_config = NdfcPythonConfig()
+    ndfc_config.filename = args.config
+    ndfc_config.commit()
+    config = ndfc_config.contents["config"]
+except ValueError as error:
+    msg = f"Exiting: Error detail: {error}"
+    log.error(msg)
+    sys.exit()
 
-nc = NdfcCredentials()
-ndfc = NDFC()
-ndfc.domain = nc.nd_domain
-ndfc.ip4 = nc.ndfc_ip
-ndfc.password = nc.password
-ndfc.username = nc.username
-ndfc.login()
+rest_send = RestSend({})
+rest_send.sender = ndfc_sender.sender
+rest_send.response_handler = ResponseHandler()
 
 try:
-    instance = NdfcVrf()
-    instance.ndfc = ndfc
-    instance.display_name = "MyVrf"
-    instance.fabric = "f1"
-    instance.vrf_id = 50055
-    instance.vrf_name = "MyVrf"
-    instance.vrf_vlan_id = 2006
-    instance.post()
-except (NdfcRequestError, ValueError) as error:
+    instance = VrfCreate()
+    instance.rest_send = rest_send
+    instance.results = Results()
+    instance.display_name = config.get("vrf_display_name")
+    instance.fabric_name = config.get("fabric_name")
+    instance.vrf_id = config.get("vrf_id")
+    instance.vrf_name = config.get("vrf_name")
+    instance.vrf_vlan_id = config.get("vrf_vlan_id")
+    instance.commit()
+except ValueError as error:
     msg = "Error creating vrf. "
     msg += f"Error detail: {error}"
     log.error(msg)

--- a/lib/ndfc_python/vrf_create.py
+++ b/lib/ndfc_python/vrf_create.py
@@ -8,11 +8,14 @@ import json
 import logging
 from ipaddress import AddressValueError
 
-from ndfc_python.ndfc import NdfcRequestError
+from plugins.module_utils.common.properties import Properties
+
 from ndfc_python.validations import Validations
 
 
-class NdfcVrf:
+@Properties.add_rest_send
+@Properties.add_results
+class VrfCreate:
     """
     Create VRFs
     """
@@ -23,14 +26,8 @@ class NdfcVrf:
 
         self.validations = Validations()
 
-        # properties not passed to NDFC
-        # order is important for these three
-        self._internal_properties = {}
-        self._init_internal_properties()
-
-        # post/get base headers
-        self._headers = {}
-        self._headers["Content-Type"] = "application/json"
+        self._rest_send = None
+        self._results = None
 
         self._payload_set = set()
         self._payload_set.add("display_name")
@@ -105,9 +102,6 @@ class NdfcVrf:
         self._init_payload()
         self._init_vrf_template_config()
 
-    def _init_internal_properties(self):
-        self._internal_properties["ndfc"] = None
-
     def _init_payload(self):
         """
         initialize the REST payload
@@ -150,92 +144,106 @@ class NdfcVrf:
         """
         verify the following:
 
-        - ndfc is set and is an NDFC instance
+        - verify rest_send is set
+        - verify results is set
         - all mandatory parameters are set
-        - self.vrf does not already exist in self.fabric
+        - self.vrf does not already exist in self.fabric_name
         """
         method_name = inspect.stack()[0][3]
-        try:
-            self.validations.verify_ndfc(self.ndfc)
-        except (AttributeError, TypeError) as error:
+        # pylint: disable=no-member
+        if self.rest_send is None:
             msg = f"{self.class_name}.{method_name}: "
-            msg += f"Error detail: {error}"
-            raise ValueError(msg) from error
+            msg += f"{self.class_name}.rest_send must be set before calling "
+            msg += f"{self.class_name}.commit"
+            raise ValueError(msg)
+        if self.results is None:
+            msg = f"{self.class_name}.{method_name}: "
+            msg += f"{self.class_name}.results must be set before calling "
+            msg += f"{self.class_name}.commit"
+            raise ValueError(msg)
+        # pylint: enable=no-member
 
         for param in self.mandatory_payload_set:
             if self.payload[param] == "":
                 msg = f"{self.class_name}.{method_name}: "
                 msg += f"Call {self.class_name}.{param} before calling "
-                msg += f"{self.class_name}.post()"
+                msg += f"{self.class_name}.commit"
                 raise ValueError(msg)
         for param in self.mandatory_template_config_set:
             if self.template_config[param] == "":
                 msg = f"{self.class_name}.{method_name}: "
                 msg += f"Call {self.class_name}.{param} before calling "
-                msg += f"{self.class_name}.post()"
+                msg += f"{self.class_name}.commit"
                 raise ValueError(msg)
         if self.vrf_exists_in_fabric():
             msg = f"{self.class_name}.{method_name}: "
             msg += f"VRF {self.vrf_name} already exists in "
-            msg += f"fabric {self.fabric}"
+            msg += f"fabric {self.fabric_name}"
             raise ValueError(msg)
 
-    def post(self):
+    def commit(self):
         """
-        post the resquest
+        # Summary
+        Commit VRF creation
+
+        # Raises
+        - ValueError if unable to send request to the controller
         """
         method_name = inspect.stack()[0][3]
         self._final_verification()
 
-        url = f"{self.ndfc.url_top_down_fabrics}/{self.fabric}/vrfs"
-
-        headers = {}
-        headers["Authorization"] = self.ndfc.bearer_token
-        headers["Content-Type"] = "application/json"
-
+        # path = f"{self.ndfc.url_top_down_fabrics}/{self.fabric_name}/vrfs"
+        path = "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/top-down/fabrics"
+        path += f"/{self.fabric_name}/vrfs"
         self.payload["vrfTemplateConfig"] = json.dumps(self.template_config)
 
+        # pylint: disable=no-member
         try:
-            self.ndfc.post(url, headers, self.payload)
-        except NdfcRequestError as error:
+            self.rest_send.path = path
+            self.rest_send.verb = "POST"
+            self.rest_send.payload = self.payload
+            self.rest_send.commit()
+        except (TypeError, ValueError) as error:
             msg = f"{self.class_name}.{method_name}: "
-            msg += "Error sending POST request to the controller. "
-            msg += f"Error detail: {error}"
+            msg += f"Unable to send {self.rest_send.verb} request to the controller. "
+            msg += f"Error details: {error}"
             raise ValueError(msg) from error
+        # pylint: enable=no-member
 
     def vrf_exists_in_fabric(self):
         """
-        Return True if self.vrf exists in self.fabric.
+        Return True if self.vrf exists in self.fabric_name.
         Else, return False
         """
-        url = f"{self.ndfc.url_top_down_fabrics}/{self.fabric}/vrfs"
+        method_name = inspect.stack()[0][3]
+        # TODO: update when this path is added to ansible-dcnm
+        path = f"/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/top-down/fabrics/{self.fabric_name}/vrfs"
+        verb = "GET"
 
-        self._headers["Authorization"] = self.ndfc.bearer_token
+        # pylint: disable=no-member
+        try:
+            self.rest_send.path = path
+            self.rest_send.verb = verb
+            self.rest_send.payload = self.payload
+            self.rest_send.commit()
+        except (TypeError, ValueError) as error:
+            msg = f"{self.class_name}.{method_name}: "
+            msg += f"Unable to send {self.rest_send.verb} request to the controller. "
+            msg += f"Error details: {error}"
+            raise ValueError(msg) from error
 
-        response = self.ndfc.get(url, self._headers)
-        for item_d in response:
+        for item_d in self.rest_send.response_current["DATA"]:
             if "fabric" not in item_d:
                 continue
             if "vrfName" not in item_d:
                 continue
-            if item_d["fabric"] != self.fabric:
+            if item_d["fabric"] != self.fabric_name:
                 continue
             if item_d["vrfName"] != self.vrf_name:
                 continue
             return True
+        # pylint: enable=no-member
         return False
-
-    # properties that are not passed to NDFC
-    @property
-    def ndfc(self):
-        """
-        return/set the current ndfc instance
-        """
-        return self._internal_properties["ndfc"]
-
-    @ndfc.setter
-    def ndfc(self, param):
-        self._internal_properties["ndfc"] = param
 
     # top_level properties
     @property
@@ -250,15 +258,15 @@ class NdfcVrf:
         self.payload["displayName"] = param
 
     @property
-    def fabric(self):
+    def fabric_name(self):
         """
         return the current payload value of VRF fabric
         """
         return self.payload["fabric"]
 
-    @fabric.setter
-    def fabric(self, param):
-        self.payload["fabric"] = param
+    @fabric_name.setter
+    def fabric_name(self, value):
+        self.payload["fabric"] = value
 
     @property
     def vrf_extension_template(self):

--- a/lib/ndfc_python/vrf_create.py
+++ b/lib/ndfc_python/vrf_create.py
@@ -8,9 +8,8 @@ import json
 import logging
 from ipaddress import AddressValueError
 
-from plugins.module_utils.common.properties import Properties
-
 from ndfc_python.validations import Validations
+from plugins.module_utils.common.properties import Properties
 
 
 @Properties.add_rest_send


### PR DESCRIPTION
# Summary

1. lib/ndc_python/ndfc_vrf.py
    - Renamed to vrf_create.py
    - Changes to leverage RestSend and Sender from the DCNM Ansible Collection

2. examples/vrf_add.py
    - import and use latest classes for config parsing, logging, RestSend, Results.

3. examples/config_vrf_add.yaml
    - example vrf configuration
