### PR TITLE
NetworkCreate: network_name should be mandatory

### DIFF
--- a/lib/ndfc_python/network_create.py
+++ b/lib/ndfc_python/network_create.py
@@ -275,7 +275,7 @@ class NetworkCreate:
         """
         self._payload_mapping_dict = {}
         self._payload_mapping_dict["displayName"] = "display_name"
-        self._payload_mapping_dict["fabric"] = "fabric"
+        self._payload_mapping_dict["fabric"] = "fabric_name"
         self._payload_mapping_dict[
             "networkExtensionTemplate"
         ] = "network_extension_template"

--- a/lib/ndfc_python/network_create.py
+++ b/lib/ndfc_python/network_create.py
@@ -153,6 +153,7 @@ class NetworkCreate:
         set of all mandatory payload keys
         """
         self._payload_set_mandatory.add("fabric")
+        self._payload_set_mandatory.add("networkName")
         self._payload_set_mandatory.add("networkId")
         self._payload_set_mandatory.add("vrf")
 


### PR DESCRIPTION
1. Add networkName to _payload_set_mandatory
2. Update value of _payload_mapping_dict["fabric"] to "fabric_name" since the property name changed