### PR TITLE
Reorganize credentials

### DIFF
--- a/docs/classes/overview.md
+++ b/docs/classes/overview.md
@@ -4,8 +4,8 @@
 
 Library                   | Description
 --------------------------| -----------
+[CredentialsAnsibleVault] | Read an Ansible Vault and provide properties for credentials
 [Log]                     | Create the base ndfc_python logging object
-[AnsibleVaultCredentials] | Read an Ansible Vault and provide properties for credentials
 [NdfcDiscover]            | Discover device
 [NdfcPolicy]              | ``*`` Create / delete policies
 [NdfcPythonLogger]        | Configure logging for ``ndfc-python`` scripts
@@ -18,8 +18,8 @@ Library                   | Description
 [Validations]             | Validation methods used by the other classes (deprecated)
 [YamlReader]              | Read a YAML file and return its contents as a python dict
 
+[CredentialsAnsibleVault]: https://github.com/allenrobel/ndfc-python/blob/main/lib/ndfc_python/credentials/credentials_ansible_vault.py
 [Log]: https://github.com/allenrobel/ndfc-python/blob/main/lib/ndfc_python/log_v2.py
-[AnsibleVaultCredentials]: https://github.com/allenrobel/ndfc-python/blob/main/lib/ndfc_python/ansible_vault_credentials.py
 [NdfcDiscover]: https://github.com/allenrobel/ndfc-python/blob/main/lib/ndfc_python/ndfc_discover.py
 [NdfcPolicy]: https://github.com/allenrobel/ndfc-python/blob/main/lib/ndfc_python/ndfc_policy.py
 [NdfcPythonLogger]: https://github.com/allenrobel/ndfc-python/blob/main/lib/ndfc_python/ndfc_python_logger.py

--- a/docs/scripts/credentials.md
+++ b/docs/scripts/credentials.md
@@ -61,7 +61,7 @@ nxos_username admin
 ``` bash
 (.venv) AROBEL-M-G793% ./credentials.py --ansible-vault $HOME/.ansible/vault
 Vault password:
-AnsibleVaultCredentials.commit: Exiting. ansible_vault is missing key nd_password. vault file: /Users/arobel/.ansible/vault
+CredentialsAnsibleVault.commit: Exiting. ansible_vault is missing key nd_password. vault file: /Users/arobel/.ansible/vault
 (.venv) AROBEL-M-G793%
 ```
 
@@ -70,7 +70,7 @@ AnsibleVaultCredentials.commit: Exiting. ansible_vault is missing key nd_passwor
 ``` bash
 (.venv) AROBEL-M-G793% ./credentials.py --ansible-vault /tmp/not_an_ansible_vault
 Vault password: user enters password
-AnsibleVaultCredentials.commit: Exiting. Unable to load credentials in  /tmp/not_an_ansible_vault. Exception detail: Unable to retrieve file contents
+CredentialsAnsibleVault.commit: Exiting. Unable to load credentials in  /tmp/not_an_ansible_vault. Exception detail: Unable to retrieve file contents
 Could not find or access '/tmp/not_an_ansible_vault' on the Ansible Controller.
 If you are using a module and expect the file to exist on the remote, see the remote_src option
 (.venv) AROBEL-M-G793%

--- a/examples/credentials.py
+++ b/examples/credentials.py
@@ -9,7 +9,7 @@ import argparse
 import logging
 import sys
 
-from ndfc_python.ansible_vault_credentials import AnsibleVaultCredentials
+from ndfc_python.credentials.credentials_ansible_vault import CredentialsAnsibleVault
 from ndfc_python.ndfc_python_logger import NdfcPythonLogger
 from ndfc_python.parsers.parser_ansible_vault import parser_ansible_vault
 from ndfc_python.parsers.parser_loglevel import parser_loglevel
@@ -43,11 +43,12 @@ log = logging.getLogger("ndfc_python.main")
 log.setLevel = args.loglevel
 
 try:
-    avc = AnsibleVaultCredentials()
+    avc = CredentialsAnsibleVault()
     avc.ansible_vault = args.ansible_vault
     avc.commit()
 except ValueError as error:
-    msg = f"{error}"
+    msg = "Perhaps an incorrect vault password was entered? "
+    msg += f"Error detail: {error}"
     log.error(msg)
     print(msg)
     sys.exit(1)

--- a/lib/ndfc_python/credentials/credentials_ansible_vault.py
+++ b/lib/ndfc_python/credentials/credentials_ansible_vault.py
@@ -94,7 +94,6 @@ class CredentialsAnsibleVault:
             msg += f"Exception detail: AnsibleVaultPasswordError: {error}"
             raise ValueError(msg) from error
 
-
         for key in self.mandatory_vault_keys:
             if key not in data:
                 msg = f"{self.class_name}.{method_name}: "


### PR DESCRIPTION
Move credentials libraries into lib/ndfc_python/credentials/*

This is in anticipation of loading credentials from multiple sources, including ENV and CLI.

Rename AnsibleVaultCredentials to CredentialsAnsibleVault in anticipation of adding CredentialsCli and CredentialsEnv.