### PR TITLE
Read ND_* environment variables.

### DIFF
--- a/docs/scripts/fabric_details.md
+++ b/docs/scripts/fabric_details.md
@@ -7,17 +7,17 @@ Returns fabric details.
 ## Usage
 
 ``` bash
-export NDFC_DOMAIN=local
-export NDFC_IP4=10.1.1.1
-export NDFC_PASSWORD=MySecret
-export NDFC_USERNAME=admin
+export ND_DOMAIN=local
+export ND_IP4=10.1.1.1
+export ND_PASSWORD=MySecret
+export ND_USERNAME=admin
 ./fabric_details.py --config config/config_fabric_details.yaml
 ```
 
 Environment variables (all, or a subset) can be overridden on the command line.
 
 ``` bash
-./fabric_details.py --config config/config_fabric_details.yaml --username admin --password MySecret --domain local --ip4 10.1.1.1
+./fabric_details.py --config config/config_fabric_details.yaml --nd-username admin --nd-password MySecret --nd-domain local --nd-ip4 10.1.1.1
 ```
 
 ## Example Config File
@@ -394,7 +394,7 @@ Fabric MyFabric does not exist on the controller
 #### Invalid credentials
 
 ``` bash
-(.venv) AROBEL-M-G793% ./fabric_details.py --config prod/config_fabric_details.yaml --username SomeRandomDude
+(.venv) AROBEL-M-G793% ./fabric_details.py --config prod/config_fabric_details.yaml --nd-username SomeRandomDude
 Exiting.  Error detail: NdfcPythonSender.commit: Unable to login to the controller. Error detail: Sender.update_token: Unable to parse token from response: {'RETURN_CODE': 401, 'DATA': {'error': 'Invalid Username/Password'}, 'MESSAGE': 'Unauthorized', 'METHOD': 'POST', 'REQUEST_PATH': 'https://10.1.1.1/login'}
 (.venv) AROBEL-M-G793%
 ```

--- a/docs/scripts/rest_get_request.md
+++ b/docs/scripts/rest_get_request.md
@@ -12,10 +12,10 @@ Either set the following environment variables or use the command line
 options to set the credentials for your Nexus Dashboard controller.
 
 ``` bash title="Set environment variables"
-export NDFC_DOMAIN=local
-export NDFC_IP4=10.1.1.1
-export NDFC_PASSWORD=MyNdfcPassword
-export NDFC_USERNAME=admin
+export ND_DOMAIN=local
+export ND_IP4=10.1.1.1
+export ND_PASSWORD=MyNdfcPassword
+export ND_USERNAME=admin
 ```
 
 ``` bash title="If the above environment variables are set"
@@ -23,7 +23,7 @@ export NDFC_USERNAME=admin
 ```
 
 ``` bash title="If the above environment variables are not set"
-./rest_get_request.py --domain local --password MyNdfcPassword --username admin --ip4 10.1.1.1
+./rest_get_request.py --nd-domain local --nd-password MyNdfcPassword --nd-username admin --nd-ip4 10.1.1.1
 ```
 
 ### Logging
@@ -402,7 +402,7 @@ export NDFC_LOGGING_CONFIG=$HOME/repos/ndfc-python/lib/ndfc_python/logging_confi
 ### Failure - Login credentials are invalid
 
 ``` bash title="Invalid login credentials"
-(.venv) AROBEL-M-G793% ./rest_get_request.py --domain local --username admin --password TotallyIncorrectPassword --ip4 10.1.1.1
+(.venv) AROBEL-M-G793% ./rest_get_request.py --nd-domain local --nd-username admin --nd-password TotallyIncorrectPassword --nd-ip4 10.1.1.1
 Exiting.  Error detail: NdfcPythonSender.commit: Unable to login to the controller. Error detail: Sender.update_token: Unable to parse token from response: {'RETURN_CODE': 401, 'DATA': {'error': 'Invalid Username/Password'}, 'MESSAGE': 'Unauthorized', 'METHOD': 'POST', 'REQUEST_PATH': 'https://10.1.1.1/login'}
 (.venv) AROBEL-M-G793%
 ```

--- a/docs/scripts/rest_post_request.md
+++ b/docs/scripts/rest_post_request.md
@@ -12,10 +12,10 @@ Either set the following environment variables or use the command line
 options to set the credentials for your Nexus Dashboard controller.
 
 ``` bash title="Set environment variables"
-export NDFC_DOMAIN=local
-export NDFC_IP4=10.1.1.1
-export NDFC_PASSWORD=MyNdfcPassword
-export NDFC_USERNAME=admin
+export ND_DOMAIN=local
+export ND_IP4=10.1.1.1
+export ND_PASSWORD=MyNdfcPassword
+export ND_USERNAME=admin
 ```
 
 ``` bash title="If the above environment variables are set"
@@ -23,7 +23,7 @@ export NDFC_USERNAME=admin
 ```
 
 ``` bash title="If the above environment variables are not set"
-./rest_post_request.py --domain local --password MyNdfcPassword --username admin --ip4 10.1.1.1
+./rest_post_request.py --nd-domain local --nd-password MyNdfcPassword --nd-username admin --nd-ip4 10.1.1.1
 ```
 
 ### Logging
@@ -395,7 +395,7 @@ export NDFC_LOGGING_CONFIG=$HOME/repos/ndfc-python/lib/ndfc_python/logging_confi
 ### Failure - Login credentials are invalid
 
 ``` bash title="Invalid login credentials"
-(.venv) AROBEL-M-G793% ./rest_post_request.py --username foo
+(.venv) AROBEL-M-G793% ./rest_post_request.py --nd-username foo
 Exiting.  Error detail: NdfcPythonSender.commit: Unable to login to the controller. Error detail: Sender.update_token: Unable to parse token from response: {'RETURN_CODE': 401, 'DATA': {'error': 'Invalid Username/Password'}, 'MESSAGE': 'Unauthorized', 'METHOD': 'POST', 'REQUEST_PATH': 'https://10.1.1.1/login'}
 (.venv) AROBEL-M-G793%
 ```

--- a/docs/setup/credentials.md
+++ b/docs/setup/credentials.md
@@ -1,0 +1,75 @@
+# Credentials
+
+Credentials to access the Nexus Dashboard can be set in a few ways.
+
+## Environment variables
+
+Credentials can be set using the following environment variables.
+
+### ND_DOMAIN
+
+Nexus Dashboard login domain
+
+### ND_IP4
+
+Nexus Dashboard IPv4 address
+
+### ND_PASSWORD
+
+Nexus Dashboard password
+
+### ND_USERNAME
+
+Nexus Dashboard username
+
+### NXOS_PASSWORD
+
+Password for NX-OS switches.
+Used for Nexus Dashboard Fabric Contoller switch discovery
+
+### NXOS_USERNAME
+
+Username for NX-OS switches.
+Used for Nexus Dashboard Fabric Contoller switch discovery
+
+## Script command-line options
+
+Script command line options, when available, override environment variables.
+
+That is, if environment variables are set for ND_PASSWORD and ND_USERNAME,
+you can override the password (while using the value of ND_USERNAME) with:
+
+``` bash title="Override environment variable"
+./script_name.py --nd_password MyNewPassword
+```
+
+### nd_domain
+
+Nexus Dashboard login domain
+
+### nd_ip4
+
+Nexus Dashboard IPv4 address
+
+### nd_password
+
+Nexus Dashboard password
+
+### nd_username
+
+Nexus Dashboard username
+
+### nxos_password
+
+Password for NX-OS switches.
+Used for Nexus Dashboard Fabric Contoller switch discovery
+
+### nxos_username
+
+Username for NX-OS switches.
+Used for Nexus Dashboard Fabric Contoller switch discovery
+
+## Ansible Vault
+
+Lastly, for some example scripts, you can read the credentials from
+an Ansible Vault.  See [Using Ansible Vault](using-ansible-vault.md)

--- a/docs/setup/using-ansible-vault.md
+++ b/docs/setup/using-ansible-vault.md
@@ -2,8 +2,15 @@
 
 We've temporarily removed support for
 [Ansible Vault](https://docs.ansible.com/ansible/latest/vault_guide/vault.html)
-in the example scripts. It'll return later (probably as the same command-line
-option that Ansible itself uses, i.e. `--vault-password-file`)
+from some of the example scripts while we work on a unified approach to handling
+credentials. Ansible Vault support will return later (probably as a command-line
+option `--ansible-vault` and environment variable, maybe something like
+`NDFC_PYTHON_ANSIBLE_VAULT`)
+
+## Scripts which support Ansible Vault
+
+* [credentials.py](../scripts/credentials.md)
+* [reachability.py](../scripts/reachability.md)
 
 <!---
 

--- a/examples/credentials.py
+++ b/examples/credentials.py
@@ -5,6 +5,7 @@ Description:
 
 Print Ansible Vault credentials.
 """
+# pylint: disable=duplicate-code
 import argparse
 import logging
 import sys

--- a/examples/device_info.py
+++ b/examples/device_info.py
@@ -19,7 +19,7 @@ config:
 ```
 
 If you've set the standard Nexus Dashboard credentials environment variables
-(NDFC_DOMAIN, NDFC_IP4, NDFC_PASSWORD, NDFC_USERNAME) then you're good to go.
+(ND_DOMAIN, ND_IP4, ND_PASSWORD, ND_USERNAME) then you're good to go.
 
 ```bash
 ./device_info.py --config device_info_config.yaml
@@ -28,10 +28,11 @@ If you've set the standard Nexus Dashboard credentials environment variables
 You can override the environment variables like so:
 
 ```bash
-./device_info.py --config device_info_config.yaml --username admin --password MyPassword --domain local --ip4 10.1.1.2
+./device_info.py --config device_info_config.yaml --nd-username admin --nd-password MyPassword --nd-domain local --nd-ip4 10.1.1.2
 ```
 
 """
+# pylint: disable=duplicate-code
 import argparse
 import logging
 import sys

--- a/examples/discover.py
+++ b/examples/discover.py
@@ -19,10 +19,10 @@ Usage
 
     Environment variables read by Sender()
 
-    export NDFC_DOMAIN=local
-    export NDFC_IP4=10.1.1.1
-    export NDFC_PASSWORD=MyNdfcPassword
-    export NDFC_USERNAME=MyNdfcUsername
+    export ND_DOMAIN=local
+    export ND_IP4=10.1.1.1
+    export ND_PASSWORD=MyNdfcPassword
+    export ND_USERNAME=MyNdfcUsername
 
 2. Script variables
 
@@ -35,6 +35,7 @@ Usage
 
 
 """
+# pylint: disable=duplicate-code
 import logging
 import sys
 

--- a/examples/discover_is_reachable.py
+++ b/examples/discover_is_reachable.py
@@ -17,10 +17,10 @@ you override them on the command line (use --help for details):
 
 Environment variables read by Sender()
 
-export NDFC_DOMAIN=local
-export NDFC_IP4=10.1.1.1
-export NDFC_PASSWORD=MyNdfcPassword
-export NDFC_USERNAME=MyNdfcUsername
+export ND_DOMAIN=local
+export ND_IP4=10.1.1.1
+export ND_PASSWORD=MyNdfcPassword
+export ND_USERNAME=MyNdfcUsername
 
 
 ## 2. Edit config file
@@ -41,6 +41,7 @@ config:
 
 ./discover_is_reachable.py --config discover_config.yaml
 """
+# pylint: disable=duplicate-code
 import argparse
 import logging
 import sys

--- a/examples/discover_is_up.py
+++ b/examples/discover_is_up.py
@@ -17,10 +17,10 @@ you override them on the command line (use --help for details):
 
 Environment variables read by Sender()
 
-export NDFC_DOMAIN=local
-export NDFC_IP4=10.1.1.1
-export NDFC_PASSWORD=MyNdfcPassword
-export NDFC_USERNAME=MyNdfcUsername
+export ND_DOMAIN=local
+export ND_IP4=10.1.1.1
+export ND_PASSWORD=MyNdfcPassword
+export ND_USERNAME=MyNdfcUsername
 
 
 ## 2. Edit config file
@@ -41,6 +41,7 @@ config:
 
 ./discover_is_up.py --config discover_config.yaml
 """
+# pylint: disable=duplicate-code
 import argparse
 import logging
 import sys

--- a/examples/fabric_details.py
+++ b/examples/fabric_details.py
@@ -13,13 +13,13 @@ Usage:
     # The following contains the path to your Ansible Vault.  Not needed if you
     # are not using Ansible Vault.
     export NDFC_PYTHON_CONFIG=$HOME/repos/ndfc-python/lib/ndfc_python/config/config.yml
-    export NDFC_USERNAME=admin
-    export NDFC_PASSWORD=MyPassword
-    export NDFC_DOMAIN=local
-    export NDFC_IP4=10.1.1.1
+    export ND_USERNAME=admin
+    export ND_PASSWORD=MyPassword
+    export ND_DOMAIN=local
+    export ND_IP4=10.1.1.1
 
-1a. Alternately, you can override NDFC_USERNAME, NDFC_PASSWORD,
-    NDFC_DOMAIN, and NDFC_IP4 within the script.  Examples:
+1a. Alternately, you can override ND_USERNAME, ND_PASSWORD,
+    ND_DOMAIN, and ND_IP4 within the script.  Examples:
 
     Explicitly setting these:
 
@@ -32,12 +32,12 @@ Usage:
 
 2a. If you'd rather use Ansible Vault, modify the script to include:
 
-    nc = NdfcCredentials()
+    cav = CredentialsAnsibleVault()
     sender = Sender()
-    sender.username = nc.username
-    sender.password = nc.password
-    sender.domain = nc.nd_domain
-    sender.ip4 = nc.ndfc_ip
+    sender.username = cav.nd_username
+    sender.password = cav.nd_password
+    sender.domain = cav.nd_domain
+    sender.ip4 = cav.nd_ip4
     sender.login()
 
 
@@ -52,6 +52,7 @@ Usage:
 3. Set the FABRIC_NAME variable in the script below.
 
 """
+# pylint: disable=duplicate-code
 import argparse
 import json
 import logging

--- a/examples/load_config.py
+++ b/examples/load_config.py
@@ -6,6 +6,7 @@ Description:
 Load the configuration file pointed to by the environment variable NDFC_CONFIG_FILE,
 and print the parameters and values contained therein.
 """
+# pylint: disable=duplicate-code
 
 from ndfc_python.ndfc_config import NdfcLoadConfig
 

--- a/examples/login.py
+++ b/examples/login.py
@@ -14,13 +14,13 @@ Usage:
     # The following contains the path to your Ansible Vault.  Not needed if you
     # are not using Ansible Vault.
     export NDFC_PYTHON_CONFIG=$HOME/repos/ndfc-python/lib/ndfc_python/config/config.yml
-    export NDFC_USERNAME=admin
-    export NDFC_PASSWORD=MyPassword
-    export NDFC_DOMAIN=local
-    export NDFC_IP4=10.1.1.1
+    export ND_USERNAME=admin
+    export ND_PASSWORD=MyPassword
+    export ND_DOMAIN=local
+    export ND_IP4=10.1.1.1
 
-1a. Alternately, you can override NDFC_USERNAME, NDFC_PASSWORD,
-    NDFC_DOMAIN, and NDFC_IP4 within the script.  Examples:
+1a. Alternately, you can override ND_USERNAME, ND_PASSWORD,
+    ND_DOMAIN, and ND_IP4 within the script.  Examples:
 
     Explicitly setting these:
 
@@ -33,12 +33,12 @@ Usage:
 
 2a. If you'd rather use Ansible Vault, modify the script to include:
 
-    nc = NdfcCredentials()
+    cav = CredentialsAnsibleVault()
     sender = Sender()
-    sender.username = nc.username
-    sender.password = nc.password
-    sender.domain = nc.nd_domain
-    sender.ip4 = nc.ndfc_ip
+    sender.username = cav.nd_username
+    sender.password = cav.nd_password
+    sender.domain = cav.nd_domain
+    sender.ip4 = cav.nd_ip4
     sender.login()
 
 
@@ -51,6 +51,7 @@ Usage:
     ansible_vault: "/path/to/your/ansible/vault"
 
 """
+# pylint: disable=duplicate-code
 import argparse
 import logging
 import sys

--- a/examples/netbox_ndfc_network_create.py
+++ b/examples/netbox_ndfc_network_create.py
@@ -35,6 +35,7 @@ pip install pynetbox
     to the NDFC controller and once for access to your Netbox instance.
 
 """
+# pylint: disable=duplicate-code
 import logging
 import sys
 
@@ -46,7 +47,7 @@ except ImportError:
 try:
     from ndfc_python.log_v2 import Log
     from ndfc_python.ndfc import NDFC, NdfcRequestError
-    from ndfc_python.ndfc_credentials import NdfcCredentials
+    from ndfc_python.credentials.credentials_ansible_vault import NdfcCredentials
     from ndfc_python.ndfc_network import NdfcNetwork
 except ImportError:
     unable_to_import.append("ndfc-python")

--- a/examples/netbox_ndfc_network_create.py
+++ b/examples/netbox_ndfc_network_create.py
@@ -45,9 +45,9 @@ try:
 except ImportError:
     unable_to_import.append("requests")
 try:
+    from ndfc_python.credentials.credentials_ansible_vault import NdfcCredentials
     from ndfc_python.log_v2 import Log
     from ndfc_python.ndfc import NDFC, NdfcRequestError
-    from ndfc_python.credentials.credentials_ansible_vault import NdfcCredentials
     from ndfc_python.ndfc_network import NdfcNetwork
 except ImportError:
     unable_to_import.append("ndfc-python")

--- a/examples/network_create.py
+++ b/examples/network_create.py
@@ -15,6 +15,7 @@ export NDFC_LOGGING_CONFIG=$HOME/repos/ndfc-python/lib/ndfc_python/logging_confi
 
 2. Edit the network values in the script below.
 """
+# pylint: disable=duplicate-code
 import argparse
 import json
 import logging

--- a/examples/network_delete.py
+++ b/examples/network_delete.py
@@ -15,6 +15,7 @@ export NDFC_LOGGING_CONFIG=$HOME/repos/ndfc-python/lib/ndfc_python/logging_confi
 
 2. Edit the network values in the script below.
 """
+# pylint: disable=duplicate-code
 import argparse
 import json
 import logging

--- a/examples/reachability.py
+++ b/examples/reachability.py
@@ -5,6 +5,7 @@ Description:
 
 Test for device reachability (from controller perspective)
 """
+# pylint: disable=duplicate-code
 import argparse
 import json
 import logging

--- a/examples/read_config_file.py
+++ b/examples/read_config_file.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+# pylint: disable=duplicate-code
 import argparse
 import logging
 import sys

--- a/examples/vrf_create.py
+++ b/examples/vrf_create.py
@@ -2,7 +2,7 @@
 """
 # Name
 
-vrf_add.py
+vrf_create.py
 
 # Description
 
@@ -10,7 +10,7 @@ Add a vrf to a fabric
 
 #Usage
 
-Edit ``examples/config_vrf_add.yaml`` appropriately for your setup.
+Edit ``examples/config_vrf_create.yaml`` appropriately for your setup.
 
 ```yaml
 config:
@@ -22,19 +22,20 @@ config:
 ```
 
 If you've set the standard ndfc-python Nexus Dashboard credentials
-environment variables (NDFC_DOMAIN, NDFC_IP4, NDFC_PASSWORD, NDFC_USERNAME)
+environment variables (ND_DOMAIN, ND_IP4, ND_PASSWORD, ND_USERNAME)
 then you're good to go.
 
 ```bash
-./vrf_add.py --config config_vrf_add.yaml
+./vrf_create.py --config config_vrf_create.yaml
 ```
 
 If you haven't set the standard ndfc-python Nexus Dashboard credentials
 environment variables, you can override them like so:
 
 ```bash
-./vrf_add.py --config device_info_config.yaml --username admin --password MyPassword --domain local --ip4 10.1.1.2
+./vrf_create.py --config device_info_config.yaml --nd-username admin --nd-password MyPassword --nd-domain local --nd-ip4 10.1.1.2
 """
+# pylint: disable=duplicate-code
 import argparse
 import logging
 import sys

--- a/lib/ndfc_python/ndfc_discover.py
+++ b/lib/ndfc_python/ndfc_discover.py
@@ -101,10 +101,10 @@ class NdfcDiscover:
 
     Environment variables read by Sender()
 
-    NDFC_DOMAIN=local
-    NDFC_IP4=10.1.1.1
-    NDFC_PASSWORD=MyNdfcPassword
-    NDFC_USERNAME=MyNdfcUsername
+    ND_DOMAIN=local
+    ND_IP4=10.1.1.1
+    ND_PASSWORD=MyNdfcPassword
+    ND_USERNAME=MyNdfcUsername
 
 
     from ndfc_python.log_v2 import Log

--- a/lib/ndfc_python/ndfc_python_sender.py
+++ b/lib/ndfc_python/ndfc_python_sender.py
@@ -51,18 +51,18 @@ class NdfcPythonSender:
         If not set, Sender() will read Nexus Dashboard credentials from
         environment variables:
 
-        - NDFC_DOMAIN : The login domain for the Nexus Dashboard controller
-        - NDFC_IP4 : The IPv4 address of the Nexus Dashboard controller
-        - NDFC_PASSWORD : The login password for the Nexus Dashboard controller
-        - NDFC_USERNAME : The login username for the Nexus Dashboard controller
+        - ND_DOMAIN : The login domain for the Nexus Dashboard controller
+        - ND_IP4 : The IPv4 address of the Nexus Dashboard controller
+        - ND_PASSWORD : The login password for the Nexus Dashboard controller
+        - ND_USERNAME : The login username for the Nexus Dashboard controller
 
         If set, it must be an argparse.Namespace instance containing one or
         more of:
 
-        - ndfc_domain : The login domain for the Nexus Dashboard controller
-        - ndfc_ip4 : The IPv4 address of the Nexus Dashboard controller
-        - ndfc_password : The login password for the Nexus Dashboard controller
-        - ndfc_username : The login username for the Nexus Dashboard controller
+        - nd_domain : The login domain for the Nexus Dashboard controller
+        - nd_ip4 : The IPv4 address of the Nexus Dashboard controller
+        - nd_password : The login password for the Nexus Dashboard controller
+        - nd_username : The login username for the Nexus Dashboard controller
         """
         return self._args
 
@@ -98,25 +98,25 @@ class NdfcPythonSender:
             # environment variable.
             try:
                 if self.args.controller_domain is not None:
-                    # override NDFC_DOMAIN env variable
+                    # override ND_DOMAIN env variable
                     self.sender.domain = self.args.controller_domain
             except AttributeError:
                 pass
             try:
                 if self.args.controller_ip4 is not None:
-                    # override NDFC_IP4 env variable
+                    # override ND_IP4 env variable
                     self.sender.ip4 = self.args.controller_ip4
             except AttributeError:
                 pass
             try:
                 if self.args.controller_password is not None:
-                    # override NDFC_PASSWORD env variable
+                    # override ND_PASSWORD env variable
                     self.sender.password = self.args.controller_password
             except AttributeError:
                 pass
             try:
                 if self.args.controller_username is not None:
-                    # override NDFC_USERNAME env variable
+                    # override ND_USERNAME env variable
                     self.sender.username = self.args.controller_username
             except AttributeError:
                 pass

--- a/lib/ndfc_python/parsers/parser_config.py
+++ b/lib/ndfc_python/parsers/parser_config.py
@@ -5,6 +5,4 @@ parser_help += "e.g. /home/myself/myfile.yaml"
 
 parser_config = argparse.ArgumentParser(add_help=False)
 mandatory = parser_config.add_argument_group(title="MANDATORY ARGS")
-mandatory.add_argument(
-    "-c", "--config", dest="config", required=True, help=f"{parser_help}"
-)
+mandatory.add_argument("-c", "--config", dest="config", required=True, help=f"{parser_help}")

--- a/lib/ndfc_python/parsers/parser_controller_domain.py
+++ b/lib/ndfc_python/parsers/parser_controller_domain.py
@@ -1,10 +1,10 @@
 import argparse
 
 parser_help = "Login domain for the Nexus Dashboard controller. "
-parser_help += "If missing, the environment variable NDFC_DOMAIN is used. "
+parser_help += "If missing, the environment variable ND_DOMAIN is used. "
 
 parser_controller_domain = argparse.ArgumentParser(add_help=False)
 optional = parser_controller_domain.add_argument_group(title="OPTIONAL ARGS")
 optional.add_argument(
-    "-d", "--domain", dest="controller_domain", required=False, help=f"{parser_help}"
+    "--nd-domain", dest="controller_domain", required=False, help=f"{parser_help}"
 )

--- a/lib/ndfc_python/parsers/parser_controller_domain.py
+++ b/lib/ndfc_python/parsers/parser_controller_domain.py
@@ -5,6 +5,4 @@ parser_help += "If missing, the environment variable ND_DOMAIN is used. "
 
 parser_controller_domain = argparse.ArgumentParser(add_help=False)
 optional = parser_controller_domain.add_argument_group(title="OPTIONAL ARGS")
-optional.add_argument(
-    "--nd-domain", dest="controller_domain", required=False, help=f"{parser_help}"
-)
+optional.add_argument("--nd-domain", dest="controller_domain", required=False, help=f"{parser_help}")

--- a/lib/ndfc_python/parsers/parser_controller_ip4.py
+++ b/lib/ndfc_python/parsers/parser_controller_ip4.py
@@ -5,6 +5,4 @@ parser_help += "If missing, the environment variable ND_IP4 is used. "
 
 parser_controller_ip4 = argparse.ArgumentParser(add_help=False)
 optional = parser_controller_ip4.add_argument_group(title="OPTIONAL ARGS")
-optional.add_argument(
-    "--nd-ip4", dest="controller_ip4", required=False, help=f"{parser_help}"
-)
+optional.add_argument("--nd-ip4", dest="controller_ip4", required=False, help=f"{parser_help}")

--- a/lib/ndfc_python/parsers/parser_controller_ip4.py
+++ b/lib/ndfc_python/parsers/parser_controller_ip4.py
@@ -1,10 +1,10 @@
 import argparse
 
 parser_help = "IPv4 address for the Nexus Dashboard controller. "
-parser_help += "If missing, the environment variable NDFC_IP4 is used. "
+parser_help += "If missing, the environment variable ND_IP4 is used. "
 
 parser_controller_ip4 = argparse.ArgumentParser(add_help=False)
 optional = parser_controller_ip4.add_argument_group(title="OPTIONAL ARGS")
 optional.add_argument(
-    "--ip4", dest="controller_ip4", required=False, help=f"{parser_help}"
+    "--nd-ip4", dest="controller_ip4", required=False, help=f"{parser_help}"
 )

--- a/lib/ndfc_python/parsers/parser_controller_password.py
+++ b/lib/ndfc_python/parsers/parser_controller_password.py
@@ -1,13 +1,12 @@
 import argparse
 
 parser_help = "Password for the Nexus Dashboard controller. "
-parser_help += "If missing, the environment variable NDFC_PASSWORD is used. "
+parser_help += "If missing, the environment variable ND_PASSWORD is used. "
 
 parser_controller_password = argparse.ArgumentParser(add_help=False)
 optional = parser_controller_password.add_argument_group(title="OPTIONAL ARGS")
 optional.add_argument(
-    "-p",
-    "--password",
+    "--nd-password",
     dest="controller_password",
     required=False,
     help=f"{parser_help}",

--- a/lib/ndfc_python/parsers/parser_controller_username.py
+++ b/lib/ndfc_python/parsers/parser_controller_username.py
@@ -1,13 +1,12 @@
 import argparse
 
 parser_help = "Username for the Nexus Dashboard controller. "
-parser_help += "If missing, the environment variable NDFC_USERNAME is used. "
+parser_help += "If missing, the environment variable ND_USERNAME is used. "
 
 parser_controller_username = argparse.ArgumentParser(add_help=False)
 optional = parser_controller_username.add_argument_group(title="OPTIONAL ARGS")
 optional.add_argument(
-    "-u",
-    "--username",
+    "--nd-username",
     dest="controller_username",
     required=False,
     help=f"{parser_help}",


### PR DESCRIPTION
Since NDFC is being fully-integrated into Nexus Dashboard (i.e. NDFC will no longer be a separate app), we're changing the environment variable names that sender_requests.py reads from NDFC_* to ND_*.   Accordingly, we've modified all scripts and classes to follow suit.

For consistency, we are also changing the command-line arguments from e.g. --password to --nd-password.

Lastly, am adding a pylint directive to ignore duplicate code in all example scripts.