### PR TITLE
mkdocs: Updates to documentation

### DIFF
--- a/docs/classes/CredentialSelector.md
+++ b/docs/classes/CredentialSelector.md
@@ -22,14 +22,14 @@ and return the value of the credential from that source.
 
 #### credential_name
 
-The name of the credential for which to retrieve the value.  See
+The name of the credential from which to retrieve the value.  See
 [Credentials](../setup/set-credentials.md) for the list of supported
 credential names.
 
 #### script_args
 
 An instance of `parser.parse_args()` (from Python's `argparse` library)
-containing one or more [Credentials](../setup/set-credentials.md).
+containing zero or more [Credentials](../setup/set-credentials.md).
 
 If `script_args` contains `ansible_vault` i.e. the user passed
 `--ansible-vault /path/to/vault` on the script command-line, then
@@ -62,5 +62,5 @@ good example in that it demonstrates how to read and use `nxos_password` and
 
 ## See also
 
-[Credentials](../setup/set-credentials.md)
-[Running the example scripts](../setup/running-the-example-scripts.md)
+- [Credentials](../setup/set-credentials.md)
+- [Running the example scripts](../setup/running-the-example-scripts.md)

--- a/docs/scripts/credentials.md
+++ b/docs/scripts/credentials.md
@@ -6,34 +6,7 @@ Read credentials specific to `ndfc-python` from an Ansible Vault file and print 
 
 ## Expected keys
 
-The following keys are expected to be present in the Ansible Vault.
-An error will result if these are not present.
-
-### nd_domain
-
-Nexus Dashboard login domain
-
-### nd_ip4
-
-Nexus Dashboard IPv4 address
-
-### nd_password
-
-Nexus Dashboard password
-
-### nd_username
-
-Nexus Dashboard username
-
-### nxos_password
-
-NX-OS switches password.
-Used for Nexus Dashboard Fabric Contoller switch discovery
-
-### nxos_username
-
-NX-OS switches username.
-Used for Nexus Dashboard Fabric Contoller switch discovery
+See [Credentials](../setup/set-credentials.md) for the credential names and values expected by `ndfc-python`.
 
 ## Example Usage
 

--- a/docs/setup/enable-logging.md
+++ b/docs/setup/enable-logging.md
@@ -6,5 +6,56 @@ If you want to enable script logging (optional), set the following environment v
 export NDFC_LOGGING_CONFIG=$HOME/repos/ndfc-python/lib/ndfc_python/logging_config.json
 ```
 
-This is a standard Pyton logging configuration file.  There is an example
-file in this repository at ``lib/ndfc_python/logging_config.json``
+`NDFC_LOGGING_CONFIG` should point to a standard Pyton logging configuration file.  There is an example file in this repository at ``lib/ndfc_python/logging_config.json``.  Below is the contents.
+
+``` json "Example logging configuration file"
+{
+  "version": 1,
+  "formatters": {
+    "standard": {
+      "class": "logging.Formatter",
+      "format": "%(asctime)s - %(levelname)s - [%(name)s.%(funcName)s.%(lineno)d] %(message)s"
+    }
+  },
+  "handlers": {
+    "console": {
+        "class": "logging.StreamHandler",
+        "formatter": "standard",
+        "stream"  : "ext://sys.stdout"
+      },
+    "file": {
+      "class": "logging.handlers.RotatingFileHandler",
+      "formatter": "standard",
+      "filename": "/tmp/ndfc-python.log",
+      "mode": "a",
+      "encoding": "utf-8",
+      "maxBytes": 50000000,
+      "backupCount": 4
+    }
+  },
+  "loggers": {
+        "ndfc_python": {
+        "handlers": [
+            "console",
+            "file"
+        ],
+        "level": "DEBUG",
+        "propagate": false
+        },
+        "dcnm": {
+            "handlers": [
+            "console",
+            "file"
+            ],
+            "level": "DEBUG",
+            "propagate": false
+        },
+        "root": {
+            "level": "INFO",
+            "handlers": [
+            "file"
+            ]
+        }
+    }
+}
+```

--- a/docs/setup/set-credentials.md
+++ b/docs/setup/set-credentials.md
@@ -2,6 +2,57 @@
 
 Credentials to access the Nexus Dashboard can be set in a few ways.
 
+## Script command-line options
+
+Script command line options, take precedence over everything else (environment
+variables and Ansible Vault).
+
+That is, if environment variables are set for `ND_PASSWORD` and `ND_USERNAME`,
+and your Ansible Vault contains `nd_domain`, you can override `ND_PASSWORD`
+and `nd_domain` (while using the value of ND_USERNAME) with:
+
+``` bash title="Override environment variable"
+./script_name.py --nd_password MyNewPassword --nd-domain local --ansible-vault $HOME/.ansible/vault
+```
+
+### --nd-domain
+
+Nexus Dashboard login domain.
+
+Sets `args.nd_domain` within scripts.
+
+### --nd-ip4
+
+Nexus Dashboard IPv4 address
+
+Sets `args.nd_ip4` within scripts.
+
+### --nd-password
+
+Nexus Dashboard password
+
+Sets `args.nd_password` within scripts.
+
+### --nd-username
+
+Nexus Dashboard username
+
+Sets `args.nd_username` within scripts.
+
+### --nxos-password
+
+Password for NX-OS switches.
+Used for Nexus Dashboard Fabric Contoller switch discovery
+
+Sets `args.nxos_password` within scripts.
+
+### --nxos-username
+
+Username for NX-OS switches.
+Used for Nexus Dashboard Fabric Contoller switch discovery
+
+Sets `args.nxos_username` within scripts.
+
 ## Environment variables
 
 Credentials can be set using the following environment variables.
@@ -32,20 +83,28 @@ Used for Nexus Dashboard Fabric Contoller switch discovery
 Username for NX-OS switches.
 Used for Nexus Dashboard Fabric Contoller switch discovery
 
-## Script command-line options
 
-Script command line options, when available, override environment variables.
+## Ansible Vault
 
-That is, if environment variables are set for ND_PASSWORD and ND_USERNAME,
-you can override the password (while using the value of ND_USERNAME) with:
+Lastly, for most example scripts, you can read the credentials from
+an Ansible Vault.  See [Using Ansible Vault](using-ansible-vault.md)
+for details around encrypting key/values in a vault.
 
-``` bash title="Override environment variable"
-./script_name.py --nd_password MyNewPassword
+To indicate to the script that an Ansible Vault should be used
+as credential source, use the following command line argument.
+It should point to a valid Ansible Vault file.
+
+### --ansible-vault $HOME/.ansible/vault
+
+``` bash "Use Ansible Vault as a credential source"
+./my_script.py --ansible-vault $HOME/.ansible/vault
 ```
+
+The credential names within the vault file must be as follows.
 
 ### nd_domain
 
-Nexus Dashboard login domain
+Nexus Dashboard login domain.
 
 ### nd_ip4
 
@@ -68,8 +127,3 @@ Used for Nexus Dashboard Fabric Contoller switch discovery
 
 Username for NX-OS switches.
 Used for Nexus Dashboard Fabric Contoller switch discovery
-
-## Ansible Vault
-
-Lastly, for some example scripts, you can read the credentials from
-an Ansible Vault.  See [Using Ansible Vault](using-ansible-vault.md)

--- a/docs/setup/set-credentials.md
+++ b/docs/setup/set-credentials.md
@@ -83,7 +83,6 @@ Used for Nexus Dashboard Fabric Contoller switch discovery
 Username for NX-OS switches.
 Used for Nexus Dashboard Fabric Contoller switch discovery
 
-
 ## Ansible Vault
 
 Lastly, for most example scripts, you can read the credentials from

--- a/docs/setup/using-ansible-vault.md
+++ b/docs/setup/using-ansible-vault.md
@@ -1,6 +1,6 @@
 # Using Ansible Vault
 
-Most `ndfc-python` scripts now include a `--ansible-vault` command line argument.
+Most `ndfc-python` scripts now include an `--ansible-vault` command line argument.
 When this argument is present, you'll be asked for your vault password, and the
 script will read the vault for any of the credentials it needs.
 


### PR DESCRIPTION
- docs/setup/using-ansible-vault.md
    - minor grammatical fix

- docs/setup/set-credentials.md
    - List credential sources in order of precedence
    - Add example for overriding arguments via command line
    - Add more detail around Ansible Vault credential names
    - Provide example --ansible-vault argument usage

- docs/setup/enable-logging.md
    - Add example logging config file

- docs/scripts/credentials.md
    - Remove list of credentials in favor of adding a link to setup/set-credentials.md

- docs/classes/CredentialSelector.md
    - Grammatical fixes
    - script_args can contain zero credentials
    - Fix list format in 'See also' section