### PR TITLE
develop: Update credentials docs and scripts

### DIFF
--- a/docs/scripts/credentials.md
+++ b/docs/scripts/credentials.md
@@ -1,36 +1,92 @@
-# credentials.py
+# [credentials.py]
+
+[credentials.py]: https://github.com/allenrobel/ndfc-python/blob/main/examples/credentials.py
 
 ## Description
 
-Read credentials specific to `ndfc-python` from an Ansible Vault file and print them.
+Print the credentials that would be used from the hierarchy of credential
+sources that `ndfc-python` scripts traverse.
 
-## Expected keys
+## Credentials hierarchy and precedence
 
-See [Credentials](../setup/set-credentials.md) for the credential names and values expected by `ndfc-python`.
+For details around `ndfc-python`'s credentials hierarchy and precedence, and
+the credential names used, see [Credentials](../setup/set-credentials.md).
 
 ## Example Usage
 
-``` bash
-./credentials.py --ansible-vault $HOME/.ansible/vault
+### Mix of credential sources
+
+Below, the `NXOS_USERNAME` environment variable is set, so its value
+is used unless overridden by the command line.  In this case, we can
+omit `--nxos-username` from the command line.
+
+``` bash title="Mix of command line args and enviroment variables"
+(.venv) AROBEL-M-G793% export NXOS_USERNAME=admin
+(.venv) AROBEL-M-G793% ./credentials.py \
+    --nd-domain local \
+    --nd-ip4 10.1.1.1 \
+    --nd-password foo \
+    --nd-username admin \
+    --nxos-password bar
+The following credentials would be used:
+  nd_domain local
+  nd_ip4 10.1.1.1
+  nd_password foo
+  nd_username admin
+  nxos_password bar
+  nxos_username admin
 ```
 
-## Sample output
+### Overriding a lower precedence credential
 
-### Success
+Below, we override the `NXOS_USERNAME` environment variable with its
+corresponding (higher precedence) command line argument:
 
-``` bash
+``` bash title="Override environment variable"
+(.venv) AROBEL-M-G793% export NXOS_USERNAME=admin
+(.venv) AROBEL-M-G793% ./credentials.py \
+    --nd-domain local \
+    --nd-ip4 10.1.1.1 \
+    --nd-password foo \
+    --nd-username admin \
+    --nxos-password bar \
+    --nxos-username beeblebrox
+The following credentials would be used:
+  nd_domain local
+  nd_ip4 10.1.1.1
+  nd_password foo
+  nd_username admin
+  nxos_password bar
+  nxos_username beeblebrox
+```
+
+Below, we unset `NXOS_USERNAME` and point to an Ansible Vault file
+which contains all of the credentials that `ndfc-python` knows about.
+The Ansible vault file is the lowest precedence source of credentials
+but, since we haven't specified any command-line credentials, and no
+environment variables are set, the Ansible Vault file is used.
+
+Notice that the script asks for the Ansible Vault password to that
+it can read the vault.
+
+```bash
+(.venv) AROBEL-M-G793% unset NXOS_USERNAME
 (.venv) AROBEL-M-G793% ./credentials.py --ansible-vault $HOME/.ansible/vault
-Vault password: user enters password
-nd_domain local
-nd_ip4 10.1.1.1
-nd_password MySuperSecretNdPassword
-nd_username admin
-nxos_password MySuperSecretNxosPassword
-nxos_username admin
+Vault password:
+The following credentials would be used:
+  nd_domain local
+  nd_ip4 10.2.1.1
+  nd_password FooPassword
+  nd_username admin
+  nxos_password BarPassword
+  nxos_username admin
 (.venv) AROBEL-M-G793%
 ```
 
 ### Failure - Ansible Vault missing expected content
+
+Below, we are pointing `--ansible-vault` at a file that does not contain the expected
+credential names.
 
 ``` bash
 (.venv) AROBEL-M-G793% ./credentials.py --ansible-vault $HOME/.ansible/vault
@@ -41,11 +97,13 @@ CredentialsAnsibleVault.commit: Exiting. ansible_vault is missing key nd_passwor
 
 ### Failure - Ansible Vault file is missing
 
+Below, we are pointing `--ansible-vault` at a file that does not exist.
+
 ``` bash
-(.venv) AROBEL-M-G793% ./credentials.py --ansible-vault /tmp/not_an_ansible_vault
-Vault password: user enters password
-CredentialsAnsibleVault.commit: Exiting. Unable to load credentials in  /tmp/not_an_ansible_vault. Exception detail: Unable to retrieve file contents
-Could not find or access '/tmp/not_an_ansible_vault' on the Ansible Controller.
+(.venv) AROBEL-M-G793% ./credentials.py --ansible-vault /tmp/no_files_here
+Vault password:
+CredentialsAnsibleVault.commit: Exiting. Unable to load credentials in  /tmp/no_files_here. Exception detail: Unable to retrieve file contents
+Could not find or access '/tmp/no_files_here' on the Ansible Controller.
 If you are using a module and expect the file to exist on the remote, see the remote_src option
 (.venv) AROBEL-M-G793%
 ```

--- a/examples/credentials.py
+++ b/examples/credentials.py
@@ -1,19 +1,96 @@
 #!/usr/bin/env python
 """
-Name: credentials.py
-Description:
+# Name
 
-Print Ansible Vault credentials.
+credentials.py
+
+## Description
+
+Print the credentials that would be used from the hierarchy of credential
+sources that ndfc-python traverses.
+
+For details about ndfc-python's credentials hierarchy and precedence, see:
+
+https://allenrobel.github.io/ndfc-python/setup/set-credentials/
+
+## Usage
+
+Below, the NXOS_USERNAME environment variable is set, so its value
+is used unless overridden by the command line.
+
+```bash
+(.venv) AROBEL-M-G793% export NXOS_USERNAME=admin
+(.venv) AROBEL-M-G793% ./credentials.py \
+    --nd-domain local \
+    --nd-ip4 10.1.1.1 \
+    --nd-password foo \
+    --nd-username admin \
+    --nxos-password bar
+The following credentials would be used:
+  nd_domain local
+  nd_ip4 10.1.1.1
+  nd_password foo
+  nd_username admin
+  nxos_password bar
+  nxos_username admin
+```
+
+Below, we override the NXOS_USERNAME environment variable with its
+corresponding command line argument:
+
+```bash
+(.venv) AROBEL-M-G793% export NXOS_USERNAME=admin
+(.venv) AROBEL-M-G793% ./credentials.py \
+    --nd-domain local \
+    --nd-ip4 10.1.1.1 \
+    --nd-password foo \
+    --nd-username admin \
+    --nxos-password bar \
+    --nxos-username beeblebrox
+The following credentials would be used:
+  nd_domain local
+  nd_ip4 10.1.1.1
+  nd_password foo
+  nd_username admin
+  nxos_password bar
+  nxos_username beeblebrox
+```
+
+Below, we unset NXOS_USERNAME and point to an Ansible vault file
+which contains all the credentials.  The Ansible vault file is
+the lowest precedence source of credentials but, since we haven't
+specified any command-line credentials, and no environment variables
+are set, the Ansible vault file is used.
+
+```bash
+(.venv) AROBEL-M-G793% unset NXOS_USERNAME
+(.venv) AROBEL-M-G793% ./credentials.py --ansible-vault $HOME/.ansible/vault
+Vault password:
+The following credentials would be used:
+  nd_domain local
+  nd_ip4 172.22.150.244
+  nd_password FooPassword
+  nd_username admin
+  nxos_password BarPassword
+  nxos_username admin
+(.venv) AROBEL-M-G793%```
+
 """
 # pylint: disable=duplicate-code
 import argparse
 import logging
 import sys
 
-from ndfc_python.credentials.credentials_ansible_vault import CredentialsAnsibleVault
 from ndfc_python.ndfc_python_logger import NdfcPythonLogger
+from ndfc_python.ndfc_python_sender import NdfcPythonSender
 from ndfc_python.parsers.parser_ansible_vault import parser_ansible_vault
 from ndfc_python.parsers.parser_loglevel import parser_loglevel
+from ndfc_python.parsers.parser_nd_domain import parser_nd_domain
+from ndfc_python.parsers.parser_nd_ip4 import parser_nd_ip4
+from ndfc_python.parsers.parser_nd_password import parser_nd_password
+from ndfc_python.parsers.parser_nd_username import parser_nd_username
+from ndfc_python.parsers.parser_nxos_password import parser_nxos_password
+from ndfc_python.parsers.parser_nxos_username import parser_nxos_username
 
 
 def setup_parser() -> argparse.Namespace:
@@ -26,37 +103,42 @@ def setup_parser() -> argparse.Namespace:
         argparse.Namespace
     """
     parser = argparse.ArgumentParser(
-        parents=[parser_loglevel, parser_ansible_vault],
-        description="DESCRIPTION: Display credentials from an Ansible Vault.",
+        parents=[
+            parser_ansible_vault,
+            parser_nd_domain,
+            parser_nd_ip4,
+            parser_nd_password,
+            parser_nd_username,
+            parser_nxos_password,
+            parser_nxos_username,
+            parser_loglevel,
+        ],
+        description="DESCRIPTION: Print information about one or more switches.",
     )
     return parser.parse_args()
 
 
 args = setup_parser()
-
-if args.ansible_vault is None:
-    msg = "Usage: credentials.py --ansible-vault /path/to/ansible/vault"
-    print(msg)
-    sys.exit(1)
-
 NdfcPythonLogger()
 log = logging.getLogger("ndfc_python.main")
 log.setLevel = args.loglevel
 
 try:
-    cav = CredentialsAnsibleVault()
-    cav.ansible_vault = args.ansible_vault
-    cav.commit()
+    ndfc_sender = NdfcPythonSender()
+    ndfc_sender.args = args
+    # Do not login, we're just printing credentials
+    ndfc_sender.login = False
+    ndfc_sender.commit()
 except ValueError as error:
-    msg = "Perhaps an incorrect vault password was entered? "
-    msg += f"Error detail: {error}"
+    msg = f"Exiting.  Error detail: {error}"
     log.error(msg)
     print(msg)
     sys.exit(1)
 
-print(f"nd_domain {cav.nd_domain}")
-print(f"nd_ip4 {cav.nd_ip4}")
-print(f"nd_password {cav.nd_password}")
-print(f"nd_username {cav.nd_username}")
-print(f"nxos_password {cav.nxos_password}")
-print(f"nxos_username {cav.nxos_username}")
+print("The following credentials would be used:")
+print(f"  nd_domain {ndfc_sender.nd_domain}")
+print(f"  nd_ip4 {ndfc_sender.nd_ip4}")
+print(f"  nd_password {ndfc_sender.nd_password}")
+print(f"  nd_username {ndfc_sender.nd_username}")
+print(f"  nxos_password {ndfc_sender.nxos_password}")
+print(f"  nxos_username {ndfc_sender.nxos_username}")

--- a/lib/ndfc_python/ndfc_python_sender.py
+++ b/lib/ndfc_python/ndfc_python_sender.py
@@ -52,6 +52,7 @@ class NdfcPythonSender:
         self._credential_names.append("nxos_password")
         self._credential_names.append("nxos_username")
         self._sender = Sender()
+        self._login = True
         self._nd_domain = None
         self._nd_ip4 = None
         self._nd_password = None
@@ -146,6 +147,8 @@ class NdfcPythonSender:
         """
         method_name = inspect.stack()[0][3]
         self.set_sender_credentials()
+        if self.login is False:
+            return
         try:
             self.sender.login()
         except ValueError as error:
@@ -201,3 +204,24 @@ class NdfcPythonSender:
         Return the NX-OS username.
         """
         return self._nxos_username
+
+    @property
+    def login(self):
+        """
+        # Summary
+        Login to the controller when commit is called.
+
+        # Raises
+        None
+
+        # Type
+        bool
+
+        # Default
+        True
+        """
+        return self._login
+
+    @login.setter
+    def login(self, value):
+        self._login = value


### PR DESCRIPTION
- lib/ndfc_python/ndfc_python_sender.py
    - Add a property "login" that defaults to True.  This is used by examples/credentials.py

- examples/credentials.py
    - Rewrite to leverage the new credentials hierarchy.

- docs/scripts/credentials.md
    - Update documentation for examples/credentials.py