### PR TITLE
mkdocs: Update script documentation

### DIFF
--- a/docs/scripts/device_info.md
+++ b/docs/scripts/device_info.md
@@ -4,27 +4,31 @@
 
 Returns switch information for one or more switches.
 
-## Usage
-
-``` bash
-./device_info.py --config config/config_device_info.yaml
-```
-
-## Example Config File
+## Example configuration file
 
 ``` yaml title="config/config_device_info.yaml"
 ---
 config:
-  - switch_ip4: 10.1.1.1
   - switch_ip4: 10.1.1.2
+  - switch_ip4: 10.1.1.3
 ```
 
-## Sample output
+## Example Usage
 
-### Success
+The example below uses environment variables for credentials, so requires
+only the `--config` argument.  See [Running the Example Scripts]
+for details around specifying credentials from the command line, from
+environment variables, from Ansible Vault, or a combination of these
+credentials sources.
 
-``` bash title="Success"
-(.venv) AROBEL-M-G793% ./device_info.py --config prod/config_device_info.yaml
+[Running the Example Scripts]: ../setup/running-the-example-scripts.md
+
+``` bash
+export ND_DOMAIN=local
+export ND_IP4=10.1.1.1
+export ND_PASSWORD=MySecret
+export ND_USERNAME=admin
+./device_info.py --config config/config_device_info.yaml
 ipv4_address 10.1.1.2
   serial_number: FDO123456AB
   fabric_name: f1
@@ -38,10 +42,12 @@ ipv4_address 10.1.1.3
 (.venv) AROBEL-M-G793%
 ```
 
-### Failure - switch does not exist
+## Sample failure output
+
+### Switch does not exist
 
 ``` bash title="switch does not exist"
 (.venv) AROBEL-M-G793% ./device_info.py --config prod/config_device_info.yaml
-Unable to get switch details. Error details: SwitchDetails._get: Switch with ip_address 10.1.1.4 does not exist on the controller.
+Unable to get switch details. Error details: SwitchDetails._get: Switch with ip_address 10.1.1.2 does not exist on the controller.
 (.venv) AROBEL-M-G793%
 ```

--- a/docs/scripts/fabric_details.md
+++ b/docs/scripts/fabric_details.md
@@ -4,7 +4,24 @@
 
 Returns fabric details for one or more fabrics.
 
-## Usage
+## Example configuration file
+
+``` yaml title="config/config_fabric_details.yaml"
+---
+config:
+  - fabric_name: MyFabric1
+  - fabric_name: MyFabric2
+```
+
+## Example Usage
+
+The example below uses environment variables for credentials, so requires
+only the `--config` argument.  See [Running the Example Scripts]
+for details around specifying credentials from the command line, from
+environment variables, from Ansible Vault, or a combination of these
+credentials sources.
+
+[Running the Example Scripts]: ../setup/running-the-example-scripts.md
 
 ``` bash
 export ND_DOMAIN=local
@@ -12,21 +29,7 @@ export ND_IP4=10.1.1.1
 export ND_PASSWORD=MySecret
 export ND_USERNAME=admin
 ./fabric_details.py --config config/config_fabric_details.yaml
-```
-
-Environment variables (all, or a subset) can be overridden on the command line.
-
-``` bash
-./fabric_details.py --config config/config_fabric_details.yaml --nd-username admin --nd-password MySecret --nd-domain local --nd-ip4 10.1.1.1
-```
-
-## Example Config File
-
-``` yaml title="config/config_fabric_details.yaml"
----
-config:
-  - fabric_name: MyFabric1
-  - fabric_name: MyFabric2
+# output not shown
 ```
 
 ## Sample output

--- a/docs/scripts/network_create.md
+++ b/docs/scripts/network_create.md
@@ -4,13 +4,7 @@
 
 Create one or more networks.
 
-## Usage
-
-``` bash
-./network_create.py --config config/config_network_create.yaml
-```
-
-## Example Config File
+## Example configuration file
 
 ``` yaml title="config/config_network_create.yaml"
 ---
@@ -30,6 +24,26 @@ config:
     vlan_id: 3006
     vrf_name: MyVrf1
 ```
+
+## Example Usage
+
+The example below uses environment variables for credentials, so requires
+only the `--config` argument.  See [Running the Example Scripts]
+for details around specifying credentials from the command line, from
+environment variables, from Ansible Vault, or a combination of these
+credentials sources.
+
+[Running the Example Scripts]: ../setup/running-the-example-scripts.md
+
+``` bash
+export ND_DOMAIN=local
+export ND_IP4=10.1.1.1
+export ND_PASSWORD=MySecret
+export ND_USERNAME=admin
+./network_create.py --config config/config_network_create.yaml
+# output not shown
+```
+
 
 ## Example output
 

--- a/docs/scripts/network_delete.md
+++ b/docs/scripts/network_delete.md
@@ -4,13 +4,7 @@
 
 Delete one or more networks.
 
-## Usage
-
-``` bash
-./network_delete.py --config config/config_network_delete.yaml
-```
-
-## Example Config File
+## Example configuration file
 
 ``` yaml title="config/config_network_delete.yaml"
 ---
@@ -19,6 +13,25 @@ config:
     network_name: MyNet1
   - fabric_name: MyFabric1
     network_name: MyNet2
+```
+
+## Example Usage
+
+The example below uses environment variables for credentials, so requires
+only the `--config` argument.  See [Running the Example Scripts]
+for details around specifying credentials from the command line, from
+environment variables, from Ansible Vault, or a combination of these
+credentials sources.
+
+[Running the Example Scripts]: ../setup/running-the-example-scripts.md
+
+``` bash
+export ND_DOMAIN=local
+export ND_IP4=10.1.1.1
+export ND_PASSWORD=MySecret
+export ND_USERNAME=admin
+./network_delete.py --config config/config_network_delete.yaml
+# output not shown
 ```
 
 ## Example output

--- a/docs/scripts/reachability.md
+++ b/docs/scripts/reachability.md
@@ -5,14 +5,6 @@
 Display reachability (from controller perspective) information for one or more
 devices.
 
-For now, this script requires Ansible to be installed since it uses Ansible
-Vault for credentials.
-
-`pip install ansible`
-
-We plan to rework this to support other credential sources soon, including
-environment variables and command line options.
-
 ## Example configuration file
 
 ``` yaml title="Example configuraion file"
@@ -24,50 +16,26 @@ config:
     seed_ip: 10.1.1.3
 ```
 
-## Expected Ansible Vault keys
-
-The following keys are expected to be present in the Ansible Vault.
-An error will result if these are not present.
-
-### nd_domain
-
-Nexus Dashboard login domain
-
-### nd_ip4
-
-Nexus Dashboard IPv4 address
-
-### nd_password
-
-Nexus Dashboard password
-
-### nd_username
-
-Nexus Dashboard username
-
-### nxos_password
-
-NX-OS switches password.
-Used for Nexus Dashboard Fabric Contoller switch discovery
-
-### nxos_username
-
-NX-OS switches username.
-Used for Nexus Dashboard Fabric Contoller switch discovery
-
 ## Example Usage
 
-``` bash
-./reachability.py --config/config_reachability.yaml --ansible-vault $HOME/.ansible/vault
-```
+The example below uses environment variables for credentials, so requires
+only the `--config` argument.  See [Running the Example Scripts]
+for details around specifying credentials from the command line, from
+environment variables, from Ansible Vault, or a combination of these
+credentials sources.
 
-## Sample output
+[Running the Example Scripts]: ../setup/running-the-example-scripts.md
 
-### Success
-
-``` bash
-(.venv) AROBEL-M-G793% ./reachability.py --config prod/config_reachability.yaml --ansible-vault $HOME/.ansible/vault
-Vault password:
+``` bash title="Example usage"
+export ND_DOMAIN=local
+export ND_IP4=10.1.1.1
+export ND_PASSWORD=MyNdPassword
+export ND_USERNAME=admin
+export NXOS_PASSWORD=MyNxosPassword
+export NXOS_USERNAME=admin
+cd $HOME/repos/ndfc-python/examples
+./reachability.py --config/config_reachability.yaml
+# output not shown
 sys_name: cvd-1313-leaf
   auth: True
   device_index: cvd-1313-leaf(FDO211218HH)
@@ -86,28 +54,43 @@ sys_name: cvd-1313-leaf
   vdc_mac: None
   vendor: Cisco
   version: 10.3(1)
-sys_name: cvd-1314-leaf
+```
+
+## Sample output
+
+### Success
+
+``` bash title="Success"
+export ND_DOMAIN=local
+export ND_IP4=10.1.1.1
+export ND_PASSWORD=MyNdPassword
+export ND_USERNAME=admin
+export NXOS_PASSWORD=MyNxosPassword
+export NXOS_USERNAME=admin
+cd $HOME/repos/ndfc-python/examples
+./reachability.py --config/config_reachability.yaml
+# output not shown
+sys_name: cvd-1313-leaf
   auth: True
-  device_index: cvd-1314-leaf(FDO211218FV)
+  device_index: cvd-1313-leaf(FDO211218HH)
   hop_count: 0
-  ip_addr: 10.1.1.3
+  ip_addr: 10.1.1.2
   known: True
   last_change: None
   platform: N9K-C93180YC-EX
   reachable: True
   selectable: False
-  serial_number: FDO123456CD
+  serial_number: FDO123456AB
   status_reason: already managed in MyFabric1
   switch_role: None
   valid: True
   vdc_id: 0
   vdc_mac: None
   vendor: Cisco
-  version: 10.2(5)
-(.venv) AROBEL-M-G793%
+  version: 10.3(1)
 ```
 
-### Failure - Ansible Vault missing expected content
+### Failure - Missing credential
 
 ``` bash
 (.venv) AROBEL-M-G793% ./reachability.py --config prod/config_reachability.yaml --ansible-vault $HOME/.ansible/vault

--- a/docs/scripts/vrf_create.md
+++ b/docs/scripts/vrf_create.md
@@ -1,0 +1,61 @@
+# vrf_create.py
+
+## Description
+
+Create one or more VRFs (virtual routing and forwarding instances).
+
+## Example configuration file
+
+``` yaml title="config/config_vrf_create.yaml"
+---
+config:
+  - fabric_name: MyFabric1
+    vrf_display_name: MyVrf1
+    vrf_id: 50005
+    vrf_name: MyVrf1
+    vrf_vlan_id: 3005
+  - fabric_name: MyFabric1
+    vrf_display_name: MyVrf2
+    vrf_id: 50006
+    vrf_name: MyVrf2
+    vrf_vlan_id: 3006
+```
+
+## Example Usage
+
+The example below uses environment variables for credentials, so requires
+only the `--config` argument.  See [Running the Example Scripts]
+for details around specifying credentials from the command line, from
+environment variables, from Ansible Vault, or a combination of these
+credentials sources.
+
+[Running the Example Scripts]: ../setup/running-the-example-scripts.md
+
+``` bash
+export ND_DOMAIN=local
+export ND_IP4=10.1.1.1
+export ND_PASSWORD=MySecret
+export ND_USERNAME=admin
+./vrf_create.py --config config/config_vrf_create.yaml
+# output not shown
+```
+
+## Example output
+
+### Success
+
+``` bash title="VRFs created successfully"
+(.venv) AROBEL-M-G793% ./vrf_create.py --config prod/config_vrf_create.yaml
+Created vrf MyVrf1 in fabric f1
+Created vrf MyVrf2 in fabric f1
+(.venv) AROBEL-M-G793%
+```
+
+### Failure - VRFs already exist in fabric MyFabric1
+
+``` bash title="VRFs exist in the target fabric"
+(.venv) AROBEL-M-G793% ./vrf_create.py --config prod/config_vrf_create.yaml
+Error creating vrf MyVrf1. Error detail: VrfCreate._final_verification: VRF MyVrf1 already exists in fabric MyFabric1
+Error creating vrf MyVrf2. Error detail: VrfCreate._final_verification: VRF MyVrf2 already exists in fabric MyFabric1
+(.venv) AROBEL-M-G793%
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,6 +82,7 @@ nav:
       - reachability.py: scripts/reachability.md
       - rest_get_request.py: scripts/rest_get_request.md
       - rest_post_request.py: scripts/rest_post_request.md
+      - vrf_create.py: scripts/vrf_create.md
   - Classes:
       - Overview: classes/overview.md
       - CredentialSelector: classes/CredentialSelector.md


### PR DESCRIPTION
1. Update script documentation for consistency of heading labels and heading order.

2. Update reachability.md to remove content specifically about Ansible Vault since `examples/reachability.py` now leverages `CredentialSource` and behaves like all the other scripts.

3. Update `Example Usage` for all scripts with explanation of credentials and a link to `docs/setup/running-the-example-scripts.md`

4. Add `docs/scripts/vrf_create.md`