### PR TITLE
develop: merge into main

### DIFF
--- a/docs/scripts/device_info.md
+++ b/docs/scripts/device_info.md
@@ -51,3 +51,13 @@ ipv4_address 10.1.1.3
 Unable to get switch details. Error details: SwitchDetails._get: Switch with ip_address 10.1.1.2 does not exist on the controller.
 (.venv) AROBEL-M-G793%
 ```
+
+### Invalid ip address in config file
+
+``` bash title="Invalid switch_ip4 value in --config"
+(.venv) AROBEL-M-G793% ./device_info.py --config prod/config_device_info.yaml
+1 validation error for DeviceInfoConfigValidator
+config.0.switch_ip4
+  Input is not a valid IPv4 address [type=ip_v4_address, input_value='foo', input_type=str]
+(.venv) AROBEL-M-G793%
+```

--- a/docs/scripts/maintenance_mode_info.md
+++ b/docs/scripts/maintenance_mode_info.md
@@ -37,7 +37,7 @@ export ND_USERNAME=admin
 ### Success
 
 ``` bash title="Successful query for two switches"
-(.venv) AROBEL-M-G793% ./maintenance_mode.py --config prod/config_maintenance_mode.yaml
+(.venv) AROBEL-M-G793% ./maintenance_mode_info.py --config prod/config_maintenance_mode_info.yaml
 {
     "changed": false,
     "diff": [
@@ -97,7 +97,7 @@ export ND_USERNAME=admin
 ### Switch does not exist on the controller
 
 ``` bash title="Switch does not exist"
-(.venv) AROBEL-M-G793% ./maintenance_mode.py --config prod/config_maintenance_mode.yaml
+(.venv) AROBEL-M-G793% ./maintenance_mode_info.py --config prod/config_maintenance_mode_info.yaml
 Exiting.  Error detail: Query.commit: Error while retrieving switch information from the controller. Error detail: Query.get_have: Error while retrieving switch info. Error detail: SwitchDetails._get: Switch with ip_address 10.1.1.8 does not exist on the controller.
 (.venv) AROBEL-M-G793%
 ```

--- a/docs/scripts/maintenance_mode_info.md
+++ b/docs/scripts/maintenance_mode_info.md
@@ -1,0 +1,113 @@
+# maintenance_mode_info.py
+
+## Description
+
+Enable or disable maintenance mode on one or more switches.
+
+## Example configuration file
+
+``` yaml title="config/config_maintenance_mode_info.yaml"
+---
+config:
+    - ip_address: 10.1.1.2
+    - ip_address: 10.1.1.3
+```
+
+## Example Usage
+
+The example below uses environment variables for credentials, so requires
+only the `--config` argument.  See [Running the Example Scripts]
+for details around specifying credentials from the command line, from
+environment variables, from Ansible Vault, or a combination of these
+credentials sources.
+
+[Running the Example Scripts]: ../setup/running-the-example-scripts.md
+
+``` bash
+export ND_DOMAIN=local
+export ND_IP4=10.1.1.1
+export ND_PASSWORD=MySecret
+export ND_USERNAME=admin
+./maintenance_mode_info.py --config config/config_maintenance_mode_info.yaml
+# output not shown
+```
+
+## Example output
+
+### Success
+
+``` bash title="Successful query for two switches"
+(.venv) AROBEL-M-G793% ./maintenance_mode.py --config prod/config_maintenance_mode.yaml
+{
+    "changed": false,
+    "diff": [
+        {
+            "10.1.1.2": {
+                "fabric_deployment_disabled": false,
+                "fabric_freeze_mode": false,
+                "fabric_name": "f1",
+                "fabric_read_only": false,
+                "ip_address": "10.1.1.2",
+                "mode": "normal",
+                "role": "spine",
+                "serial_number": "FOX5678EFGH"
+            },
+            "10.1.1.3": {
+                "fabric_deployment_disabled": false,
+                "fabric_freeze_mode": false,
+                "fabric_name": "f1",
+                "fabric_read_only": false,
+                "ip_address": "10.1.1.3",
+                "mode": "maintenance",
+                "role": "spine",
+                "serial_number": "FOX5678EFGH"
+            },
+            "sequence_number": 1
+        }
+    ],
+    "failed": false,
+    "metadata": [
+        {
+            "action": "maintenance_mode_info",
+            "check_mode": false,
+            "sequence_number": 1,
+            "state": null
+        }
+    ],
+    "response": [
+        {
+            "MESSAGE": "MaintenanceModeInfo OK.",
+            "METHOD": "NA",
+            "REQUEST_PATH": "NA",
+            "RETURN_CODE": 200,
+            "sequence_number": 1
+        }
+    ],
+    "result": [
+        {
+            "changed": false,
+            "sequence_number": 1,
+            "success": true
+        }
+    ]
+}
+(.venv) AROBEL-M-G793%
+```
+
+### Switch does not exist on the controller
+
+``` bash title="Switch does not exist"
+(.venv) AROBEL-M-G793% ./maintenance_mode.py --config prod/config_maintenance_mode.yaml
+Exiting.  Error detail: Query.commit: Error while retrieving switch information from the controller. Error detail: Query.get_have: Error while retrieving switch info. Error detail: SwitchDetails._get: Switch with ip_address 10.1.1.8 does not exist on the controller.
+(.venv) AROBEL-M-G793%
+```
+
+### Invalid config file
+
+``` bash title="config file contains incorrect value for ip_address"
+(.venv) AROBEL-M-G793% ./maintenance_mode_info.py --config prod/config_maintenance_mode_info.yaml
+1 validation error for MaintenanceModeInfoConfigValidator
+config.0.ip_address
+  Input is not a valid IPv4 address [type=ip_v4_address, input_value='foo', input_type=str]
+(.venv) AROBEL-M-G793%
+```

--- a/examples/maintenance_mode.py
+++ b/examples/maintenance_mode.py
@@ -358,9 +358,9 @@ class Merged:
         try:
             # TODO: For now, we need to pass params to MaintenanceMode.
             # This will be changed in a future ansible-dcnm release.
-            self.maintenance_mode = MaintenanceMode(self.rest_send.params)
-            self.maintenance_mode.rest_send = self.rest_send
-            self.maintenance_mode.results = self.rest_send.results
+            self.maintenance_mode = MaintenanceMode(self.rest_send.params)  # type: ignore[attr-defined]
+            self.maintenance_mode.rest_send = self.rest_send  # type: ignore[attr-defined]
+            self.maintenance_mode.results = self.rest_send.results  # type: ignore[attr-defined]
             self.maintenance_mode.config = self.need
             self.maintenance_mode.commit()
         except (TypeError, ValueError) as error:
@@ -460,7 +460,8 @@ rest_send.results = Results()
 
 try:
     task = Merged()
-    task.rest_send = rest_send  # pylint: disable=attribute-defined-outside-init
+    # pylint: disable=attribute-defined-outside-init
+    task.rest_send = rest_send  # type: ignore[attr-defined]
     task.want = ndfc_config.contents["config"]
     task.commit()
 except ValueError as error:
@@ -469,9 +470,10 @@ except ValueError as error:
     print(err_msg)
     sys.exit(1)
 
-task.rest_send.results.build_final_result()
-if True in task.rest_send.results.failed:  # pylint: disable=unsupported-membership-test
+task.rest_send.results.build_final_result()  # type: ignore[attr-defined]
+# pylint: disable=unsupported-membership-test
+if True in task.rest_send.results.failed:  # type: ignore[attr-defined]
     err_msg = "unable to set maintenance mode"
     log.error(err_msg)
     print(err_msg)
-print(json.dumps(task.rest_send.results.final_result, indent=4, sort_keys=True))
+print(json.dumps(task.rest_send.results.final_result, indent=4, sort_keys=True))  # type: ignore[attr-defined]

--- a/examples/maintenance_mode_info.py
+++ b/examples/maintenance_mode_info.py
@@ -298,7 +298,8 @@ rest_send.results = Results()
 
 try:
     task = Query()
-    task.rest_send = rest_send  # pylint: disable=attribute-defined-outside-init
+    # pylint: disable=attribute-defined-outside-init
+    task.rest_send = rest_send  # type: ignore[attr-defined]
     task.want = ndfc_config.contents["config"]
     task.commit()
 except ValueError as error:
@@ -307,9 +308,10 @@ except ValueError as error:
     print(err_msg)
     sys.exit(1)
 
-task.rest_send.results.build_final_result()
-if True in task.rest_send.results.failed:  # pylint: disable=unsupported-membership-test
+task.rest_send.results.build_final_result()  # type: ignore[attr-defined]
+# pylint: disable=unsupported-membership-test
+if True in task.rest_send.results.failed:  # type: ignore[attr-defined]
     err_msg = "unable to set maintenance mode"
     log.error(err_msg)
     print(err_msg)
-print(json.dumps(task.rest_send.results.final_result, indent=4, sort_keys=True))
+print(json.dumps(task.rest_send.results.final_result, indent=4, sort_keys=True))  # type: ignore[attr-defined]

--- a/lib/ndfc_python/validators.py
+++ b/lib/ndfc_python/validators.py
@@ -5,9 +5,10 @@ Validators for class input properties.
 """
 
 from enum import Enum
+from ipaddress import IPv4Address, IPv4Interface
 from typing import List, Optional
 
-from pydantic import BaseModel, IPvAnyInterface, PositiveInt
+from pydantic import BaseModel, PositiveInt
 
 
 class DeviceInfoConfig(BaseModel):
@@ -17,7 +18,7 @@ class DeviceInfoConfig(BaseModel):
     Base validator for DeviceInfo arguments
     """
 
-    switch_ip4: str
+    switch_ip4: IPv4Address
 
 
 class FabricDetailsConfig(BaseModel):
@@ -47,10 +48,20 @@ class MaintenanceModeConfig(BaseModel):
         maintenance = "maintenance"
         normal = "normal"
 
-    ip_address: str
+    ip_address: IPv4Address
     deploy: Optional[bool] = True
     wait_for_mode_change: Optional[bool] = True
     mode: ModeEnum
+
+
+class MaintenanceModeInfoConfig(BaseModel):
+    """
+    # Summary
+
+    Base validator for MaintenanceModeInfo arguments
+    """
+
+    ip_address: IPv4Address
 
 
 class NetworkCreateConfig(BaseModel):
@@ -61,7 +72,7 @@ class NetworkCreateConfig(BaseModel):
     """
 
     fabric_name: str
-    gateway_ip_address: Optional[IPvAnyInterface] = None
+    gateway_ip_address: Optional[IPv4Interface] = None
     is_layer2_only: Optional[bool] = None
     network_id: PositiveInt
     network_name: str
@@ -88,7 +99,7 @@ class ReachabilityConfig(BaseModel):
     """
 
     fabric_name: str
-    seed_ip: str
+    seed_ip: IPv4Address
 
 
 class VrfCreateConfig(BaseModel):
@@ -133,6 +144,16 @@ class MaintenanceModeConfigValidator(BaseModel):
     """
 
     config: List[MaintenanceModeConfig]
+
+
+class MaintenanceModeInfoConfigValidator(BaseModel):
+    """
+    # Summary
+
+    config is a list of MaintenanceModeInfoConfig
+    """
+
+    config: List[MaintenanceModeInfoConfig]
 
 
 class NetworkCreateConfigValidator(BaseModel):

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,6 +79,7 @@ nav:
       - device_info.py: scripts/device_info.md
       - fabric_details.py: scripts/fabric_details.md
       - maintenance_mode.py: scripts/maintenance_mode.md
+      - maintenance_mode_info.py: scripts/maintenance_mode_info.md
       - network_create.py: scripts/network_create.md
       - network_delete.py: scripts/network_delete.md
       - reachability.py: scripts/reachability.md


### PR DESCRIPTION
1. mkdocs.yml
    - Add link to maintenance_mode_info.py documentation

2. lib/ndfc_python/validators.py
    - Add validation for IPv4 address everywhere an IPv4 address is used
    - Add validation for IPv4 network everywhere an IPv4 network is used

3. examples/maintenance_mode.py
    - Fix description and docstring.
    - Fix initialization for self._rest_send

4. examples/maintenance_mode_info.py
    - New script

5. docs/scripts/maintenance_mode_info.md
    - Documentation for maintenance_mode_info.py

6. docs/scripts/device_info.md
    - Add example for incorrect switch_ip4 value