### PR TITLE
Add example image policy info scripts

### DIFF
--- a/docs/scripts/image_policy_info.md
+++ b/docs/scripts/image_policy_info.md
@@ -1,0 +1,159 @@
+# image_policy_info.py
+
+## Description
+
+Query one or more image policies by name.
+
+## Example configuration file
+
+``` yaml title="config/config_image_policy_info.yaml"
+---
+config:
+    - name: nxos64-cs.10.2.5.M.bin_N9K_All
+    - name: FOO_POLICY
+```
+
+## Example Usage
+
+The example below uses environment variables for credentials, so requires
+only the `--config` argument.  See [Running the Example Scripts]
+for details around specifying credentials from the command line, from
+environment variables, from Ansible Vault, or a combination of these
+credentials sources.
+
+[Running the Example Scripts]: ../setup/running-the-example-scripts.md
+
+``` bash
+export ND_DOMAIN=local
+export ND_IP4=10.1.1.2
+export ND_PASSWORD=MySecret
+export ND_USERNAME=admin
+./device_info.py --config config/config_device_info.yaml
+# output not shown
+```
+
+## Example output
+
+### Image policy exists on the controller
+
+``` bash title="Image policy exists"
+(.venv) AROBEL-M-G793% ./image_policy_info.py --config prod/config_image_policy_info.yaml
+{
+    "changed": false,
+    "diff": [
+        {
+            "agnostic": false,
+            "epldImgName": "",
+            "fabricPolicyName": "nxos64-cs.10.2.5.M.bin",
+            "imageName": "nxos64-cs.10.2.5.M.bin",
+            "imagePresent": "Present",
+            "nxosVersion": "10.2.5_nxos64-cs_64bit",
+            "packageName": "",
+            "platform": "N9K/N3K",
+            "platformPolicies": "",
+            "policyDescr": null,
+            "policyName": "nxos64-cs.10.2.5.M.bin_N9K_All",
+            "policyType": "FABRIC",
+            "ref_count": 0,
+            "role": "All",
+            "rpmimages": "false",
+            "sequence_number": 1,
+            "unInstall": false
+        }
+    ],
+    "failed": false,
+    "metadata": [
+        {
+            "action": "query",
+            "check_mode": false,
+            "sequence_number": 1,
+            "state": "query"
+        }
+    ],
+    "response": [
+        {
+            "DATA": {
+                "lastOperDataObject": [
+                    {
+                        "agnostic": false,
+                        "epldImgName": "",
+                        "fabricPolicyName": "nxos64-cs.10.2.5.M.bin",
+                        "imageName": "nxos64-cs.10.2.5.M.bin",
+                        "imagePresent": "Present",
+                        "nxosVersion": "10.2.5_nxos64-cs_64bit",
+                        "packageName": "",
+                        "platform": "N9K/N3K",
+                        "platformPolicies": "",
+                        "policyDescr": null,
+                        "policyName": "nxos64-cs.10.2.5.M.bin_N9K_All",
+                        "policyType": "FABRIC",
+                        "ref_count": 0,
+                        "role": "All",
+                        "rpmimages": "false",
+                        "unInstall": false
+                    }
+                ],
+                "message": "",
+                "status": "SUCCESS"
+            },
+            "MESSAGE": "OK",
+            "METHOD": "GET",
+            "REQUEST_PATH": "https://10.1.1.2/appcenter/cisco/ndfc/api/v1/imagemanagement/rest/policymgnt/policies",
+            "RETURN_CODE": 200,
+            "sequence_number": 1
+        }
+    ],
+    "result": [
+        {
+            "found": true,
+            "sequence_number": 1,
+            "success": true
+        }
+    ]
+}
+(.venv) AROBEL-M-G793%
+```
+
+### Image policy does not exist on the controller
+
+``` bash title="Image policy does not exist"
+(.venv) AROBEL-M-G793% ./image_policy_info.py --config prod/config_image_policy_info.yaml --nd-ip4 10.1.1.3
+{
+    "changed": false,
+    "diff": [
+        {
+            "sequence_number": 1
+        }
+    ],
+    "failed": false,
+    "metadata": [
+        {
+            "action": "query",
+            "check_mode": false,
+            "sequence_number": 1,
+            "state": "query"
+        }
+    ],
+    "response": [
+        {
+            "DATA": {
+                "lastOperDataObject": [],
+                "message": "",
+                "status": "SUCCESS"
+            },
+            "MESSAGE": "OK",
+            "METHOD": "GET",
+            "REQUEST_PATH": "https://10.1.1.3/appcenter/cisco/ndfc/api/v1/imagemanagement/rest/policymgnt/policies",
+            "RETURN_CODE": 200,
+            "sequence_number": 1
+        }
+    ],
+    "result": [
+        {
+            "sequence_number": 1,
+            "success": true
+        }
+    ]
+}
+(.venv) AROBEL-M-G793%
+```

--- a/docs/scripts/image_policy_info_all.md
+++ b/docs/scripts/image_policy_info_all.md
@@ -1,0 +1,159 @@
+# image_policy_info_all.py
+
+## Description
+
+Returns information about all image policies on the controller.
+
+## Example configuration file
+
+Configuration file is not required.
+
+## Example Usage
+
+The example below uses environment variables for credentials, so no
+arguments are required if credentials are defined as environment variables.
+
+See [Running the Example Scripts] for details around specifying credentials
+from the command line, from environment variables, from Ansible Vault, or a
+combination of these credentials sources.
+
+[Running the Example Scripts]: ../setup/running-the-example-scripts.md
+
+``` bash
+export ND_DOMAIN=local
+export ND_IP4=10.1.1.2
+export ND_PASSWORD=MySecret
+export ND_USERNAME=admin
+./image_policy_info_all.py
+# Output not shown
+```
+
+## Example output
+
+### One or more image policies exist on the controller
+
+``` bash title="Successful response"
+(.venv) AROBEL-M-G793% ./image_policy_info_all.py
+{
+    "changed": false,
+    "diff": [
+        {
+            "nxos64-cs.10.2.5.M.bin_N9K_All": {
+                "agnostic": false,
+                "epldImgName": "",
+                "fabricPolicyName": "nxos64-cs.10.2.5.M.bin",
+                "imageName": "nxos64-cs.10.2.5.M.bin",
+                "imagePresent": "Present",
+                "nxosVersion": "10.2.5_nxos64-cs_64bit",
+                "packageName": "",
+                "platform": "N9K/N3K",
+                "platformPolicies": "",
+                "policyDescr": null,
+                "policyName": "nxos64-cs.10.2.5.M.bin_N9K_All",
+                "policyType": "FABRIC",
+                "ref_count": 0,
+                "role": "All",
+                "rpmimages": "false",
+                "unInstall": false
+            },
+            "sequence_number": 1
+        }
+    ],
+    "failed": false,
+    "metadata": [
+        {
+            "action": "query_all_image_policies",
+            "check_mode": false,
+            "sequence_number": 1,
+            "state": "query"
+        }
+    ],
+    "response": [
+        {
+            "DATA": {
+                "lastOperDataObject": [
+                    {
+                        "agnostic": false,
+                        "epldImgName": "",
+                        "fabricPolicyName": "nxos64-cs.10.2.5.M.bin",
+                        "imageName": "nxos64-cs.10.2.5.M.bin",
+                        "imagePresent": "Present",
+                        "nxosVersion": "10.2.5_nxos64-cs_64bit",
+                        "packageName": "",
+                        "platform": "N9K/N3K",
+                        "platformPolicies": "",
+                        "policyDescr": null,
+                        "policyName": "nxos64-cs.10.2.5.M.bin_N9K_All",
+                        "policyType": "FABRIC",
+                        "ref_count": 0,
+                        "role": "All",
+                        "rpmimages": "false",
+                        "unInstall": false
+                    }
+                ],
+                "message": "",
+                "status": "SUCCESS"
+            },
+            "MESSAGE": "OK",
+            "METHOD": "GET",
+            "REQUEST_PATH": "https://10.1.1.2/appcenter/cisco/ndfc/api/v1/imagemanagement/rest/policymgnt/policies",
+            "RETURN_CODE": 200,
+            "sequence_number": 1
+        }
+    ],
+    "result": [
+        {
+            "found": true,
+            "sequence_number": 1,
+            "success": true
+        }
+    ]
+}
+(.venv) AROBEL-M-G793%
+```
+
+
+### No image policies exist on the controller
+
+``` bash title="No image policies exist"
+(.venv) AROBEL-M-G793% ./image_policy_info_all.py --nd-ip4 10.1.1.3
+{
+    "changed": false,
+    "diff": [
+        {
+            "sequence_number": 1
+        }
+    ],
+    "failed": false,
+    "metadata": [
+        {
+            "action": "query_all_image_policies",
+            "check_mode": false,
+            "sequence_number": 1,
+            "state": "query"
+        }
+    ],
+    "response": [
+        {
+            "DATA": {
+                "lastOperDataObject": [],
+                "message": "",
+                "status": "SUCCESS"
+            },
+            "MESSAGE": "OK",
+            "METHOD": "GET",
+            "REQUEST_PATH": "https://10.1.1.3/appcenter/cisco/ndfc/api/v1/imagemanagement/rest/policymgnt/policies",
+            "RETURN_CODE": 200,
+            "sequence_number": 1
+        }
+    ],
+    "result": [
+        {
+            "found": true,
+            "sequence_number": 1,
+            "success": true
+        }
+    ]
+}
+(.venv) AROBEL-M-G793%
+```

--- a/docs/scripts/image_policy_info_all.md
+++ b/docs/scripts/image_policy_info_all.md
@@ -112,7 +112,6 @@ export ND_USERNAME=admin
 (.venv) AROBEL-M-G793%
 ```
 
-
 ### No image policies exist on the controller
 
 ``` bash title="No image policies exist"

--- a/examples/config/config_image_policy_info.yaml
+++ b/examples/config/config_image_policy_info.yaml
@@ -1,0 +1,4 @@
+---
+config:
+    - name: MY_IMAGE_POLICY
+    - name: YOUR_IMAGE_POLICY

--- a/examples/image_policy_info.py
+++ b/examples/image_policy_info.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python
+
+import argparse
+import inspect
+import json
+import logging
+import sys
+
+from ndfc_python.ndfc_python_logger import NdfcPythonLogger
+from ndfc_python.ndfc_python_sender import NdfcPythonSender
+from ndfc_python.parsers.parser_ansible_vault import parser_ansible_vault
+from ndfc_python.parsers.parser_config import parser_config
+from ndfc_python.parsers.parser_loglevel import parser_loglevel
+from ndfc_python.parsers.parser_nd_domain import parser_nd_domain
+from ndfc_python.parsers.parser_nd_ip4 import parser_nd_ip4
+from ndfc_python.parsers.parser_nd_password import parser_nd_password
+from ndfc_python.parsers.parser_nd_username import parser_nd_username
+from ndfc_python.parsers.parser_nxos_password import parser_nxos_password
+from ndfc_python.parsers.parser_nxos_username import parser_nxos_username
+from ndfc_python.read_config import ReadConfig
+from ndfc_python.validators.image_policy_info import ImagePolicyInfoConfigValidator
+from plugins.module_utils.common.properties import Properties
+from plugins.module_utils.common.response_handler import ResponseHandler
+from plugins.module_utils.common.rest_send_v2 import RestSend
+from plugins.module_utils.common.results import Results
+from plugins.module_utils.image_policy.image_policies import ImagePolicies
+from plugins.module_utils.image_policy.query import ImagePolicyQuery
+from pydantic import ValidationError
+
+
+@Properties.add_rest_send
+class Query:
+    """
+    Handle query state
+    """
+
+    def __init__(self):
+        self.class_name = self.__class__.__name__
+        method_name = inspect.stack()[0][3]
+        self.state = "query"
+        self.check_mode = False
+
+        self.log = logging.getLogger(f"dcnm.{self.class_name}")
+        self.image_policies = None
+        self.query = None
+        self._rest_send = None
+
+        msg = f"ENTERED {self.class_name}().{method_name}: "
+        msg += f"check_mode: {self.check_mode}"
+        self.log.debug(msg)
+
+    def commit(self) -> None:
+        """
+        1.  query the fabrics in self.want that exist on the controller
+        """
+        method_name = inspect.stack()[0][3]
+        msg = f"ENTERED {self.class_name}.{method_name}: "
+        msg += f"check_mode: {self.check_mode}"
+        self.log.debug(msg)
+
+        if self._rest_send is None:
+            msg = f"{self.class_name}.{method_name}: "
+            msg += "Set rest_send before calling commit."
+            raise ValueError(msg)
+
+        if self.want is None:
+            msg = f"{self.class_name}.{method_name}: "
+            msg += "Set want before calling commit."
+            raise ValueError(msg)
+
+        if len(self.want) == 0:
+            msg = f"{self.class_name}.{method_name}: "
+            msg += "Nothing to query."
+            print("msg")
+            return
+
+        policy_names_to_query = set()
+        for want in self.want:
+            policy_names_to_query.add(want["name"])
+
+        self.image_policies = ImagePolicies()
+        self.image_policies.rest_send = self._rest_send
+        self.image_policies.results = self._rest_send.results
+
+        params = {}
+        params["check_mode"] = self.check_mode
+        params["state"] = self.state
+
+        self.query = ImagePolicyQuery()
+        self.query.params = params
+        self.query.results = self._rest_send.results
+        self.query.rest_send = self._rest_send
+        self.query.image_policies = self.image_policies
+        self.query.policy_names = list(policy_names_to_query)
+        self.query.commit()
+
+    @property
+    def want(self):
+        """
+        ### Summary
+        Return the playbook configuration.
+
+        ### Returns
+        -   list: The playbook configuration.
+        """
+        return self._want
+
+    @want.setter
+    def want(self, value):
+        """
+        ### Summary
+        Set the playbook configuration.
+
+        ### Parameters
+        -   value: The playbook configuration.
+        """
+        self._want = value
+
+
+def setup_parser() -> argparse.Namespace:
+    """
+    ### Summary
+
+    Setup script-specific parser
+
+    Returns:
+        argparse.Namespace
+    """
+    description = "DESCRIPTION: "
+    description += "Query one or more image policies by name."
+    parser = argparse.ArgumentParser(
+        parents=[
+            parser_ansible_vault,
+            parser_config,
+            parser_loglevel,
+            parser_nd_domain,
+            parser_nd_ip4,
+            parser_nd_password,
+            parser_nd_username,
+            parser_nxos_password,
+            parser_nxos_username,
+        ],
+        description=description,
+    )
+    return parser.parse_args()
+
+
+def main():
+    """
+    main entry point for module execution
+    """
+    args = setup_parser()
+    NdfcPythonLogger()
+    log = logging.getLogger("ndfc_python.main")
+    log.setLevel = args.loglevel
+
+    try:
+        ndfc_config = ReadConfig()
+        ndfc_config.filename = args.config
+        ndfc_config.commit()
+    except ValueError as error:
+        err_msg = f"Exiting: Error detail: {error}"
+        log.error(err_msg)
+        print(err_msg)
+        sys.exit(1)
+
+    try:
+        ImagePolicyInfoConfigValidator(**ndfc_config.contents)
+    except ValidationError as error:
+        err_msg = f"{error}"
+        log.error(err_msg)
+        print(err_msg)
+        sys.exit(1)
+
+    try:
+        ndfc_sender = NdfcPythonSender()
+        ndfc_sender.args = args
+        ndfc_sender.commit()
+    except ValueError as error:
+        err_msg = f"Exiting.  Error detail: {error}"
+        log.error(err_msg)
+        print(err_msg)
+        sys.exit(1)
+
+    rest_send = RestSend({})
+    rest_send.sender = ndfc_sender.sender
+    rest_send.response_handler = ResponseHandler()
+    rest_send.results = Results()
+
+    try:
+        task = Query()
+        # pylint: disable=attribute-defined-outside-init
+        task.rest_send = rest_send  # type: ignore[attr-defined]
+        task.want = ndfc_config.contents["config"]
+        task.commit()
+    except ValueError as error:
+        err_msg = f"Exiting.  Error detail: {error}"
+        log.error(err_msg)
+        print(err_msg)
+        sys.exit(1)
+
+    task.rest_send.results.build_final_result()  # type: ignore[attr-defined]
+    # pylint: disable=unsupported-membership-test
+    if True in task.rest_send.results.failed:  # type: ignore[attr-defined]
+        err_msg = "unable to query image policies"
+        log.error(err_msg)
+        print(err_msg)
+    print(json.dumps(task.rest_send.results.final_result, indent=4, sort_keys=True))  # type: ignore[attr-defined]
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/image_policy_info_all.py
+++ b/examples/image_policy_info_all.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python
+
+import argparse
+import json
+import logging
+import sys
+
+from ndfc_python.ndfc_python_logger import NdfcPythonLogger
+from ndfc_python.ndfc_python_sender import NdfcPythonSender
+from ndfc_python.parsers.parser_ansible_vault import parser_ansible_vault
+from ndfc_python.parsers.parser_loglevel import parser_loglevel
+from ndfc_python.parsers.parser_nd_domain import parser_nd_domain
+from ndfc_python.parsers.parser_nd_ip4 import parser_nd_ip4
+from ndfc_python.parsers.parser_nd_password import parser_nd_password
+from ndfc_python.parsers.parser_nd_username import parser_nd_username
+from ndfc_python.parsers.parser_nxos_password import parser_nxos_password
+from ndfc_python.parsers.parser_nxos_username import parser_nxos_username
+from plugins.module_utils.common.response_handler import ResponseHandler
+from plugins.module_utils.common.rest_send_v2 import RestSend
+from plugins.module_utils.common.results import Results
+from plugins.module_utils.image_policy.image_policies import ImagePolicies
+
+
+def setup_parser() -> argparse.Namespace:
+    """
+    ### Summary
+
+    Setup script-specific parser
+
+    Returns:
+        argparse.Namespace
+    """
+    description = "DESCRIPTION: "
+    description += "Query all image policies."
+    parser = argparse.ArgumentParser(
+        parents=[
+            parser_ansible_vault,
+            parser_loglevel,
+            parser_nd_domain,
+            parser_nd_ip4,
+            parser_nd_password,
+            parser_nd_username,
+            parser_nxos_password,
+            parser_nxos_username,
+        ],
+        description=description,
+    )
+    return parser.parse_args()
+
+
+def main():
+    """
+    main entry point for module execution
+    """
+    args = setup_parser()
+    NdfcPythonLogger()
+    log = logging.getLogger("ndfc_python.main")
+    log.setLevel = args.loglevel
+
+    try:
+        ndfc_sender = NdfcPythonSender()
+        ndfc_sender.args = args
+        ndfc_sender.commit()
+    except ValueError as error:
+        err_msg = f"Exiting.  Error detail: {error}"
+        log.error(err_msg)
+        print(err_msg)
+        sys.exit(1)
+
+    rest_send = RestSend({})
+    rest_send.sender = ndfc_sender.sender
+    rest_send.response_handler = ResponseHandler()
+    rest_send.results = Results()
+
+    image_policies = ImagePolicies()
+    image_policies.rest_send = rest_send
+    image_policies.results = rest_send.results
+    image_policies.results.action = "query_all_image_policies"
+    image_policies.results.state = "query"
+    image_policies.refresh()
+    if len(image_policies.all_policies) > 0:
+        image_policies.results.diff_current = image_policies.all_policies
+    image_policies.rest_send.results.register_task_result()
+    image_policies.rest_send.results.build_final_result()  # type: ignore[attr-defined]
+    # pylint: disable=unsupported-membership-test
+    if True in image_policies.rest_send.results.failed:  # type: ignore[attr-defined]
+        err_msg = "unable to query image policies"
+        log.error(err_msg)
+        print(err_msg)
+    print(json.dumps(image_policies.rest_send.results.final_result, indent=4, sort_keys=True))  # type: ignore[attr-defined]
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/ndfc_python/validators/image_policy_info.py
+++ b/lib/ndfc_python/validators/image_policy_info.py
@@ -1,0 +1,23 @@
+from typing import List
+
+from pydantic import BaseModel
+
+
+class ImagePolicyInfoConfig(BaseModel):
+    """
+    # Summary
+
+    Base validator for ImagePolicyInfo arguments
+    """
+
+    name: str
+
+
+class ImagePolicyInfoConfigValidator(BaseModel):
+    """
+    # Summary
+
+    config is a list of ImagePolicyInfoConfig
+    """
+
+    config: List[ImagePolicyInfoConfig]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,6 +78,8 @@ nav:
       - credentials.py: scripts/credentials.md
       - device_info.py: scripts/device_info.md
       - fabric_info.py: scripts/fabric_info.md
+      - image_policy_info.py: scripts/image_policy_info.md
+      - image_policy_info_all.py: scripts/image_policy_info_all.md
       - maintenance_mode.py: scripts/maintenance_mode.md
       - maintenance_mode_info.py: scripts/maintenance_mode_info.md
       - network_create.py: scripts/network_create.md


### PR DESCRIPTION
Add the following scripts

1. examples/image_policy_info.py
    - query one or more specific image policies by name

2. examples/image_policy_info_all.py
    - query all image policies on the controller