### PR TITLE
develop: Add example for deleting image policies

### DIFF
--- a/docs/scripts/image_policy_create.md
+++ b/docs/scripts/image_policy_create.md
@@ -43,7 +43,7 @@ export ND_DOMAIN=local
 export ND_IP4=10.1.1.1
 export ND_PASSWORD=MySecret
 export ND_USERNAME=admin
-./device_info.py --config config/config_device_info.yaml
+./image_policy_create.py --config config/config_image_policy_create.yaml
 # output not shown
 ```
 

--- a/docs/scripts/image_policy_delete.md
+++ b/docs/scripts/image_policy_delete.md
@@ -1,0 +1,118 @@
+# image_policy_delete.py
+
+## Description
+
+Create or update one or more image policies.
+
+## Example configuration file
+
+Delete image policies KR5M and NR1F, if they exist.
+
+``` yaml title="config/config_image_policy_delete.yaml"
+---
+config:
+    - name: KR5M
+    - name: NR1F
+```
+
+## Example Usage
+
+The example below uses environment variables for credentials, so requires
+only the `--config` argument.  See [Running the Example Scripts]
+for details around specifying credentials from the command line, from
+environment variables, from Ansible Vault, or a combination of these
+credentials sources.
+
+[Running the Example Scripts]: ../setup/running-the-example-scripts.md
+
+``` bash
+export ND_DOMAIN=local
+export ND_IP4=10.1.1.1
+export ND_PASSWORD=MySecret
+export ND_USERNAME=admin
+./image_policy_delete.py --config config/config_image_policy_delete.yaml
+# output not shown
+```
+
+## Example output
+
+### Image policies deleted successfully
+
+``` bash title="Image policies delete success"
+{
+    "changed": true,
+    "diff": [
+        {
+            "policyNames": [
+                "KR5M",
+                "NR1F"
+            ],
+            "sequence_number": 1
+        }
+    ],
+    "failed": false,
+    "metadata": [
+        {
+            "action": "delete",
+            "check_mode": false,
+            "sequence_number": 1,
+            "state": "deleted"
+        }
+    ],
+    "response": [
+        {
+            "DATA": "Selected policy(s) deleted successfully.",
+            "MESSAGE": "OK",
+            "METHOD": "DELETE",
+            "REQUEST_PATH": "https://10.1.1.1/appcenter/cisco/ndfc/api/v1/imagemanagement/rest/policymgnt/policy",
+            "RETURN_CODE": 200,
+            "sequence_number": 1
+        }
+    ],
+    "result": [
+        {
+            "changed": true,
+            "sequence_number": 1,
+            "success": true
+        }
+    ]
+}
+```
+
+### The specified image policies do not exist
+
+``` bash title="Image policies do not exist"
+(.venv) AROBEL-M-G793% ./image_policy_delete.py --config prod/config_image_policy_delete.yaml
+{
+    "changed": false,
+    "diff": [
+        {
+            "sequence_number": 1
+        }
+    ],
+    "failed": false,
+    "metadata": [
+        {
+            "action": "delete",
+            "check_mode": false,
+            "sequence_number": 1,
+            "state": "deleted"
+        }
+    ],
+    "response": [
+        {
+            "MESSAGE": "No image policies to delete.",
+            "RETURN_CODE": 200,
+            "sequence_number": 1
+        }
+    ],
+    "result": [
+        {
+            "changed": false,
+            "sequence_number": 1,
+            "success": true
+        }
+    ]
+}
+(.venv) AROBEL-M-G793%
+```

--- a/lib/ndfc_python/validators/image_policy_delete.py
+++ b/lib/ndfc_python/validators/image_policy_delete.py
@@ -1,0 +1,23 @@
+from typing import List
+
+from pydantic import BaseModel
+
+
+class ImagePolicyDeleteConfig(BaseModel):
+    """
+    # Summary
+
+    Base validator for ImagePolicyDelete arguments
+    """
+
+    name: str
+
+
+class ImagePolicyDeleteConfigValidator(BaseModel):
+    """
+    # Summary
+
+    config is a list of ImagePolicyDeleteConfig
+    """
+
+    config: List[ImagePolicyDeleteConfig]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,6 +79,7 @@ nav:
       - device_info.py: scripts/device_info.md
       - fabric_info.py: scripts/fabric_info.md
       - image_policy_create.py: scripts/image_policy_create.md
+      - image_policy_delete.py: scripts/image_policy_delete.md
       - image_policy_info.py: scripts/image_policy_info.md
       - image_policy_info_all.py: scripts/image_policy_info_all.md
       - maintenance_mode.py: scripts/maintenance_mode.md


### PR DESCRIPTION
1. lib/ndfc_python/validators/image_policy_delete.py
    - config validator

2. examples/image_policy_delete.py
    - Example script to delete image policies

3. examples/image_policy_create.py
    - minor cleanup

4. docs/scripts/image_policy_delete.md
    - documentation for 2 above

5. docs/scripts/image_policy_create.mn
    - minor cleanup

6. mkdocs.py
    - Add image_policy_delete.py to the nav section