### PR TITLE
develop: Add bootflash_files_delete

### DIFF
--- a/docs/scripts/bootflash_files_delete.md
+++ b/docs/scripts/bootflash_files_delete.md
@@ -4,6 +4,29 @@
 
 Delete files from flash devices on one or more switches.
 
+## Configuration parameters
+
+### targets
+
+A list of dictionaries containing the keys `filepath` and `supervisor`
+
+#### filepath
+
+Can be any file glob (obviously, some are dangerous!).
+
+##### filepath examples
+
+- `*:/*.txt` delete all `.txt` files from all flash devices on the specified supervisor
+-  `bootflash:/scanner-202411??.log` delete all scanner log files whose name implies Nov 20224
+
+#### supervisor
+
+The supervisor containing the filepath.  Can be one of `active` or `standby`.
+
+### switches
+
+A list of switch ipv4 addresses.
+
 ## Example configuration file
 
 The configuration below deletes all files with `.log` and `.yaml` extensions
@@ -11,14 +34,6 @@ from the bootflash device on the active supervisor of switches 10.1.1.2 and
 10.1.1.3.
 
 The configuration file structure is identical to [bootflash_files_info](./bootflash_files_info.md)
-
-`filepath` can be any file glob (obviously, some are dangerous!).
-
-Examples:
-
-- `*:/*.txt` delete all `.txt` files from all flash devices on the specified supervisor
--  `bootflash:/scanner-202411??.log` delete all scanner log files whose name implies Nov 20224
-
 
 ``` yaml title="config/config_bootflash_files_delete.yaml"
 ---

--- a/docs/scripts/bootflash_files_delete.md
+++ b/docs/scripts/bootflash_files_delete.md
@@ -16,12 +16,17 @@ Can be any file glob (obviously, some are dangerous!).
 
 ##### filepath examples
 
-- `*:/*.txt` delete all `.txt` files from all flash devices on the specified supervisor
--  `bootflash:/scanner-202411??.log` delete all scanner log files whose name implies Nov 20224
+###### *:/*.txt
+
+Delete all `.txt` files from all flash devices on the specified supervisor
+
+###### bootflash:/202411??.log
+
+Delete all log files whose name implies dates in Nov 2024.
 
 #### supervisor
 
-The supervisor containing the filepath.  Can be one of `active` or `standby`.
+The supervisor containing the filepath.  One of `active` or `standby`.
 
 ### switches
 

--- a/docs/scripts/bootflash_files_delete.md
+++ b/docs/scripts/bootflash_files_delete.md
@@ -19,6 +19,7 @@ Examples:
 - `*:/*.txt` delete all `.txt` files from all flash devices on the specified supervisor
 -  `bootflash:/scanner-202411??.log` delete all scanner log files whose name implies Nov 20224
 
+
 ``` yaml title="config/config_bootflash_files_delete.yaml"
 ---
 config:

--- a/docs/scripts/bootflash_files_delete.md
+++ b/docs/scripts/bootflash_files_delete.md
@@ -1,0 +1,161 @@
+# bootflash_files_delete.py
+
+## Description
+
+Delete files from flash devices on one or more switches.
+
+## Example configuration file
+
+The configuration below deletes all files with `.log` and `.yaml` extensions
+from the bootflash device on the active supervisor of switches 10.1.1.2 and
+10.1.1.3.
+
+The configuration file structure is identical to [bootflash_files_info](./bootflash_files_info.md)
+
+`filepath` can be any file glob (obviously, some are dangerous!).
+
+Examples:
+
+- `*:/*.txt` delete all `.txt` files from all flash devices on the specified supervisor
+-  `bootflash:/scanner-202411??.log` delete all scanner log files whose name implies Nov 20224
+
+``` yaml title="config/config_bootflash_files_delete.yaml"
+---
+config:
+  targets:
+    - filepath: bootflash:/*.log
+      supervisor: active
+    - filepath: bootflash:/*.yaml
+      supervisor: active
+  switches:
+  - ip_address: 10.1.1.2
+  - ip_address: 10.1.1.3
+```
+
+## Example Usage
+
+The example below uses environment variables for credentials, so requires
+only the `--config` argument.  See [Running the Example Scripts]
+for details around specifying credentials from the command line, from
+environment variables, from Ansible Vault, or a combination of these
+credentials sources.
+
+[Running the Example Scripts]: ../setup/running-the-example-scripts.md
+
+``` bash
+export ND_DOMAIN=local
+export ND_IP4=10.1.1.1
+export ND_PASSWORD=MySecret
+export ND_USERNAME=admin
+./bootflash_files_delete.py --config config/config_bootflash_files_delete.yaml
+# output not shown
+```
+
+## Example output
+
+### Files deleted successfully
+
+``` bash title="Successful deletion"
+(.venv) arobel@AROBEL-M-G793 examples % ./bootflash_files_delete.py --config prod/config_bootflash_files_delete.yaml
+{
+    "changed": true,
+    "diff": [
+        {
+            "10.1.1.2": [
+                {
+                    "date": "2024-09-27 18:56:03",
+                    "device_name": "cvd-1313-leaf",
+                    "filepath": "bootflash:/log_profile.yaml",
+                    "ip_address": "10.1.1.2",
+                    "serial_number": "FDO123456AB",
+                    "size": "2566",
+                    "supervisor": "active"
+                }
+            ],
+            "10.1.1.3": [
+                {
+                    "date": "2024-09-27 18:56:14",
+                    "device_name": "cvd-1314-leaf",
+                    "filepath": "bootflash:/log_profile.yaml",
+                    "ip_address": "10.1.1.3",
+                    "serial_number": "FDO123456BC",
+                    "size": "2468",
+                    "supervisor": "active"
+                }
+            ],
+            "sequence_number": 1
+        }
+    ],
+    "failed": false,
+    "metadata": [
+        {
+            "action": "bootflash_delete",
+            "check_mode": false,
+            "sequence_number": 1,
+            "state": "deleted"
+        }
+    ],
+    "response": [
+        {
+            "DATA": "File(s) Deleted Successfully. \nDeleted files: [log_profile.yaml][log_profile.yaml]",
+            "MESSAGE": "OK",
+            "METHOD": "DELETE",
+            "REQUEST_PATH": "https://10.1.1.1/appcenter/cisco/ndfc/api/v1/imagemanagement/rest/imagemgnt/bootFlash/bootflash-files",
+            "RETURN_CODE": 200,
+            "sequence_number": 1
+        }
+    ],
+    "result": [
+        {
+            "changed": true,
+            "sequence_number": 1,
+            "success": true
+        }
+    ]
+}
+```
+
+### Switch does not exist on the controller
+
+``` bash title="Switch does not exist on the controller"
+(.venv) arobel@AROBEL-M-G793 examples % ./bootflash_files_delete.py --config config/config_bootflash_files_delete.yaml
+Exiting.  Error detail: BootflashInfo.refresh_bootflash_info: serial_number not found for switch 10.1.1.2. Error detail SwitchDetails._get: Switch with ip_address 10.1.1.2 does not exist on the controller.
+(.venv) arobel@AROBEL-M-G793 examples %
+```
+
+### Files not found
+
+``` bash title="Files not found"
+(.venv) arobel@AROBEL-M-G793 examples % ./bootflash_files_delete.py --config prod/config_bootflash_files_delete.yaml
+{
+    "changed": false,
+    "diff": [
+        {
+            "sequence_number": 1
+        }
+    ],
+    "failed": false,
+    "metadata": [
+        {
+            "action": "bootflash_delete",
+            "check_mode": false,
+            "sequence_number": 1,
+            "state": "deleted"
+        }
+    ],
+    "response": [
+        {
+            "MESSAGE": "No files to delete.",
+            "RETURN_CODE": 200,
+            "sequence_number": 1
+        }
+    ],
+    "result": [
+        {
+            "changed": false,
+            "sequence_number": 1,
+            "success": true
+        }
+    ]
+}
+```

--- a/docs/scripts/bootflash_files_info.md
+++ b/docs/scripts/bootflash_files_info.md
@@ -19,6 +19,7 @@ Examples:
 - `*:/*.txt` list all `.txt` files from all flash devices on the specified supervisor
 -  `bootflash:/scanner-202411??.log` list all scanner log files whose name implies Nov 20224
 
+
 ``` yaml title="config/config_bootflash_files_info.yaml"
 ---
 config:

--- a/docs/scripts/bootflash_files_info.md
+++ b/docs/scripts/bootflash_files_info.md
@@ -4,21 +4,36 @@
 
 List files from flash devices on one or more switches.
 
+## Configuration parameters
+
+### targets
+
+A list of dictionaries containing the keys `filepath` and `supervisor`
+
+#### filepath
+
+Can be any file glob (obviously, some are dangerous!).
+
+##### filepath examples
+
+- `*:/*.txt` list all `.txt` files from all flash devices on the specified supervisor
+-  `bootflash:/scanner-202411??.log` list all scanner log files whose name implies Nov 20224
+
+#### supervisor
+
+The supervisor containing the filepath.  Can be one of `active` or `standby`.
+
+### switches
+
+A list of switch ipv4 addresses.
+
 ## Example configuration file
 
 The configuration below lists all files with `.log` and `.yaml` extensions
 from the bootflash device on the active supervisor of switches 10.1.1.2 and
 10.1.1.3.
 
-The configuration file structure is identical to [bootflash_files_delete](./bootflash_files_delete.md)
-
-`filepath` can be any file glob.
-
-Examples:
-
-- `*:/*.txt` list all `.txt` files from all flash devices on the specified supervisor
--  `bootflash:/scanner-202411??.log` list all scanner log files whose name implies Nov 20224
-
+The configuration file structure is identical to [delete](./bootflash_files_delete.md)
 
 ``` yaml title="config/config_bootflash_files_info.yaml"
 ---

--- a/docs/scripts/bootflash_files_info.md
+++ b/docs/scripts/bootflash_files_info.md
@@ -16,12 +16,17 @@ Can be any file glob (obviously, some are dangerous!).
 
 ##### filepath examples
 
-- `*:/*.txt` list all `.txt` files from all flash devices on the specified supervisor
--  `bootflash:/scanner-202411??.log` list all scanner log files whose name implies Nov 20224
+###### *:/*.txt
+
+List all `.txt` files from all flash devices on the specified supervisor
+
+###### bootflash:/202411??.log
+
+List all log files whose name implies dates in Nov 2024.
 
 #### supervisor
 
-The supervisor containing the filepath.  Can be one of `active` or `standby`.
+The supervisor containing the filepath.  One of `active` or `standby`.
 
 ### switches
 

--- a/docs/scripts/bootflash_files_info.md
+++ b/docs/scripts/bootflash_files_info.md
@@ -7,7 +7,17 @@ List files from flash devices on one or more switches.
 ## Example configuration file
 
 The configuration below lists all files with `.log` and `.yaml` extensions
-on switches 10.1.1.2 and 10.1.1.3.
+from the bootflash device on the active supervisor of switches 10.1.1.2 and
+10.1.1.3.
+
+The configuration file structure is identical to [bootflash_files_delete](./bootflash_files_delete.md)
+
+`filepath` can be any file glob.
+
+Examples:
+
+- `*:/*.txt` list all `.txt` files from all flash devices on the specified supervisor
+-  `bootflash:/scanner-202411??.log` list all scanner log files whose name implies Nov 20224
 
 ``` yaml title="config/config_bootflash_files_info.yaml"
 ---

--- a/examples/config/config_bootflash_files_delete.yaml
+++ b/examples/config/config_bootflash_files_delete.yaml
@@ -1,0 +1,10 @@
+---
+config:
+  targets:
+    - filepath: bootflash:/*.log
+      supervisor: active
+    - filepath: bootflash:/*.yaml
+      supervisor: active
+  switches:
+  - ip_address: 10.1.1.2
+  - ip_address: 10.1.1.3

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -74,6 +74,7 @@ nav:
       - Running the example scripts: setup/running-the-example-scripts.md
       - Using Ansible Vault: setup/using-ansible-vault.md
   - Scripts:
+      - bootflash_files_delete.py: scripts/bootflash_files_delete.md
       - bootflash_files_info.py: scripts/bootflash_files_info.md
       - controller_info.py: scripts/controller_info.md
       - credentials.py: scripts/credentials.md


### PR DESCRIPTION
1. mkdocs.yml
    - Add link to bootflash_files_delete.md

2. examples/config/config_bootflash_files_delete.yaml
    - Example config file

3. examples/bootflash_files_info.py
    - Remove unused property
    - Remove commented code

4. examples/bootflash_files_delete.py
    - Add example script to delete files on switch flash devices

5. docs/scripts/bootflash_files.info.md
    - Update to provide example file globs
    - Update with a link to bootflash_files_delete.md

6. docs/scripts/bootflash_files.delete.md
    - Documentation for bootflash_files_delete.py
