### PR TITLE
develop: refactor + add image_policy_override.py

### DIFF
--- a/docs/scripts/image_policy_override.md
+++ b/docs/scripts/image_policy_override.md
@@ -1,0 +1,260 @@
+# image_policy_override.py
+
+## Description
+
+Override the image policies on the controller with the image policies
+in the configuration file.
+
+Any image policies on the controller that are not in the configuration
+file will be deleted.  Any image policies that on the controller and
+are in the configuration will be replaced with the image policies in
+the configuration.
+
+Use this script when you want the controller configuration to exactly
+match the script configuration.
+
+## Example configuration file
+
+``` yaml title="config/config_image_policy_override.yaml"
+---
+config:
+    - name: KR5M
+      agnostic: False
+      description: KR5M
+      epld_image: n9000-epld.10.2.5.M.img
+      platform: N9K
+      release: 10.2.5_nxos64-cs_64bit
+      type: PLATFORM
+    - name: NR1F
+      description: NR1F
+      platform: N9K
+      epld_image: n9000-epld.10.3.1.F.img
+      release: 10.3.1_nxos64-cs_64bit
+```
+
+## Example Usage
+
+The example below uses environment variables for credentials, so requires
+only the `--config` argument.  See [Running the Example Scripts]
+for details around specifying credentials from the command line, from
+environment variables, from Ansible Vault, or a combination of these
+credentials sources.
+
+[Running the Example Scripts]: ../setup/running-the-example-scripts.md
+
+``` bash
+export ND_DOMAIN=local
+export ND_IP4=10.1.1.1
+export ND_PASSWORD=MySecret
+export ND_USERNAME=admin
+./image_policy_override.py --config config/config_image_policy_override.yaml
+# output not shown
+```
+
+## Example output
+
+### Image policy configurations overridden successfully
+
+Below, an image policy on the controller (`FOO_DELETE_ME`) is deleted since it is
+not represented in the configuration file.
+
+Image policies `KR5M` and `NR1F` on the controller are updated to match the
+configuration file.
+
+``` bash title="Successful execution"
+(.venv) AROBEL-M-G793% ./image_policy_override.py --config prod/config_image_policy_override.yaml
+{
+    "changed": true,
+    "diff": [
+        {
+            "policyNames": [
+                "FOO_DELETE_ME"
+            ],
+            "sequence_number": 1
+        },
+        {
+            "agnostic": false,
+            "epldImgName": "n9000-epld.10.2.5.M.img",
+            "nxosVersion": "10.2.5_nxos64-cs_64bit",
+            "packageName": "",
+            "platform": "N9K",
+            "policyDescr": "KR5M",
+            "policyName": "KR5M",
+            "policyType": "PLATFORM",
+            "rpmimages": "",
+            "sequence_number": 2
+        },
+        {
+            "agnostic": false,
+            "epldImgName": "n9000-epld.10.3.1.F.img",
+            "nxosVersion": "10.3.1_nxos64-cs_64bit",
+            "packageName": "",
+            "platform": "N9K",
+            "policyDescr": "NR1F",
+            "policyName": "NR1F",
+            "policyType": "PLATFORM",
+            "rpmimages": "",
+            "sequence_number": 3
+        }
+    ],
+    "failed": false,
+    "metadata": [
+        {
+            "action": "delete",
+            "check_mode": false,
+            "sequence_number": 1,
+            "state": "overridden"
+        },
+        {
+            "action": "replace",
+            "check_mode": false,
+            "sequence_number": 2,
+            "state": "overridden"
+        },
+        {
+            "action": "replace",
+            "check_mode": false,
+            "sequence_number": 3,
+            "state": "overridden"
+        }
+    ],
+    "response": [
+        {
+            "DATA": "Selected policy(s) deleted successfully.",
+            "MESSAGE": "OK",
+            "METHOD": "DELETE",
+            "REQUEST_PATH": "https://10.1.1.1/appcenter/cisco/ndfc/api/v1/imagemanagement/rest/policymgnt/policy",
+            "RETURN_CODE": 200,
+            "sequence_number": 1
+        },
+        {
+            "DATA": "Policy updated successfully.",
+            "MESSAGE": "OK",
+            "METHOD": "POST",
+            "REQUEST_PATH": "https://10.1.1.1/appcenter/cisco/ndfc/api/v1/imagemanagement/rest/policymgnt/edit-policy",
+            "RETURN_CODE": 200,
+            "sequence_number": 2
+        },
+        {
+            "DATA": "Policy updated successfully.",
+            "MESSAGE": "OK",
+            "METHOD": "POST",
+            "REQUEST_PATH": "https://10.1.1.1/appcenter/cisco/ndfc/api/v1/imagemanagement/rest/policymgnt/edit-policy",
+            "RETURN_CODE": 200,
+            "sequence_number": 3
+        }
+    ],
+    "result": [
+        {
+            "changed": true,
+            "sequence_number": 1,
+            "success": true
+        },
+        {
+            "changed": true,
+            "sequence_number": 2,
+            "success": true
+        },
+        {
+            "changed": true,
+            "sequence_number": 3,
+            "success": true
+        }
+    ]
+}
+```
+
+### packages.install for image policy is set to a package name that does not exist on the controller
+
+``` yaml title="Invalid config"
+---
+config:
+    - name: KR5M
+      agnostic: False
+      description: KR5M
+      epld_image: n9000-epld.10.2.5.M.img
+      packages:
+        install:
+        - bad_package_name_which_does_not_exist.rpm
+        uninstall:
+        - mtx-grpctunnel-2.1.0.0-10.4.1.lib32_64_n9000
+      platform: N9K
+      release: 10.2.5_nxos64-cs_64bit
+      type: PLATFORM
+    - name: NR1F
+      description: NR1F
+      platform: N9K
+      epld_image: n9000-epld.10.3.1.F.img
+      release: 10.3.1_nxos64-cs_64bit
+```
+
+``` bash title="install package does not exist on the controller"
+(.venv) AROBEL-M-G793% ./image_policy_override.py --config prod/config_image_policy_override.yaml
+unable to override one or more image policies
+{
+    "changed": true,
+    "diff": [
+        {
+            "sequence_number": 1
+        },
+        {
+            "agnostic": false,
+            "epldImgName": "n9000-epld.10.3.1.F.img",
+            "nxosVersion": "10.3.1_nxos64-cs_64bit",
+            "packageName": "",
+            "platform": "N9K",
+            "policyDescr": "NR1F",
+            "policyName": "NR1F",
+            "policyType": "PLATFORM",
+            "rpmimages": "",
+            "sequence_number": 2
+        }
+    ],
+    "failed": true,
+    "metadata": [
+        {
+            "action": "replace",
+            "check_mode": false,
+            "sequence_number": 1,
+            "state": "overridden"
+        },
+        {
+            "action": "replace",
+            "check_mode": false,
+            "sequence_number": 2,
+            "state": "overridden"
+        }
+    ],
+    "response": [
+        {
+            "DATA": "Invalid Package name(s).",
+            "MESSAGE": "Internal Server Error",
+            "METHOD": "POST",
+            "REQUEST_PATH": "https://10.1.1.1/appcenter/cisco/ndfc/api/v1/imagemanagement/rest/policymgnt/edit-policy",
+            "RETURN_CODE": 500,
+            "sequence_number": 1
+        },
+        {
+            "DATA": "Policy updated successfully.",
+            "MESSAGE": "OK",
+            "METHOD": "POST",
+            "REQUEST_PATH": "https://10.1.1.1/appcenter/cisco/ndfc/api/v1/imagemanagement/rest/policymgnt/edit-policy",
+            "RETURN_CODE": 200,
+            "sequence_number": 2
+        }
+    ],
+    "result": [
+        {
+            "changed": false,
+            "sequence_number": 1,
+            "success": false
+        },
+        {
+            "changed": true,
+            "sequence_number": 2,
+            "success": true
+        }
+    ]
+}
+(.venv) arobel@AROBEL-M-G793 examples %
+```

--- a/examples/config/config_image_policy_override.yaml
+++ b/examples/config/config_image_policy_override.yaml
@@ -1,0 +1,24 @@
+---
+config:
+    - name: KR5M
+      agnostic: False
+      description: KR5M
+      epld_image: n9000-epld.10.2.5.M.img
+      packages:
+        install:
+        - bad_package_name_which_does_not_exist.rpm
+        uninstall:
+        - mtx-grpctunnel-2.1.0.0-10.4.1.lib32_64_n9000
+      # packages:
+      #   install:
+      #   - cfg_cmp-0.3.1.0-1.x86_64.rpm
+      #   uninstall:
+      #   - mtx-grpctunnel-2.1.0.0-10.4.1.lib32_64_n9000
+      platform: N9K
+      release: 10.2.5_nxos64-cs_64bit
+      type: PLATFORM
+    - name: NR1F
+      description: NR1F
+      platform: N9K
+      epld_image: n9000-epld.10.3.1.F.img
+      release: 10.3.1_nxos64-cs_64bit

--- a/examples/image_policy_create.py
+++ b/examples/image_policy_create.py
@@ -20,13 +20,11 @@ __metaclass__ = type
 __author__ = "Allen Robel"
 
 import argparse
-import copy
-import inspect
 import json
 import logging
 import sys
-from typing import Any
 
+from ndfc_python.image_policy import Merged
 from ndfc_python.ndfc_python_logger import NdfcPythonLogger
 from ndfc_python.ndfc_python_sender import NdfcPythonSender
 from ndfc_python.parsers.parser_ansible_vault import parser_ansible_vault
@@ -40,270 +38,9 @@ from ndfc_python.parsers.parser_nxos_password import parser_nxos_password
 from ndfc_python.parsers.parser_nxos_username import parser_nxos_username
 from ndfc_python.read_config import ReadConfig
 from ndfc_python.validators.image_policy_create import ImagePolicyCreateConfigValidator
-from plugins.module_utils.common.merge_dicts_v2 import MergeDicts
-from plugins.module_utils.common.properties import Properties
 from plugins.module_utils.common.response_handler import ResponseHandler
 from plugins.module_utils.common.rest_send_v2 import RestSend
-from plugins.module_utils.common.results import Results
-from plugins.module_utils.image_policy.create import ImagePolicyCreateBulk
-from plugins.module_utils.image_policy.image_policies import ImagePolicies
-from plugins.module_utils.image_policy.payload import Config2Payload
-from plugins.module_utils.image_policy.update import ImagePolicyUpdateBulk
 from pydantic import ValidationError
-
-
-@Properties.add_rest_send
-class Merged:
-    """
-    # Summary
-
-    Handle merged state
-
-    # Raises
-
-    -   ``ValueError`` if:
-        -   ``params`` is missing ``config`` key.
-        -   ``commit()`` is issued before setting mandatory properties
-    """
-
-    def __init__(self, params) -> None:
-        self.class_name = self.__class__.__name__
-        self.log = logging.getLogger(f"ndfc_python.{self.class_name}")
-
-        method_name = inspect.stack()[0][3]
-
-        self._rest_send = None
-        self.have = ImagePolicies()
-        self.need: list[dict[Any, Any]] = []
-        self._want: dict[Any, Any] = {}
-
-        self.state = "merged"
-        self.check_mode = params.get("check_mode")
-
-        self.create = ImagePolicyCreateBulk()
-        self.update = ImagePolicyUpdateBulk()
-
-        # new policies to be created
-        self.need_create: list = []
-        # existing policies to be updated
-        self.need_update: list = []
-
-        msg = f"ENTERED {self.class_name}().{method_name}: "
-        msg += f"state: {self.state}, "
-        msg += f"check_mode: {self.check_mode}"
-        self.log.debug(msg)
-
-    def get_have(self) -> None:
-        """
-        Caller: main()
-
-        self.have consists of the current image policies on the controller
-        """
-        method_name = inspect.stack()[0][3]
-        msg = f"ENTERED {self.class_name}.{method_name}"
-        self.log.debug(msg)
-
-        self.have = ImagePolicies()
-        # pylint: disable=no-member
-        self.have.results = self.rest_send.results  # type: ignore[attr-defined]
-        self.have.rest_send = self.rest_send  # type: ignore[attr-defined]
-        self.have.refresh()
-        # pylint: enable=no-member
-
-    def get_need(self):
-        """
-        # Summary
-
-        Build self.need for merged state
-
-        # Description
-
-        -   Populate self.need_create with items from self.want that are
-            not in self.have
-        -   Populate self.need_update with updated policies.  Policies are
-            updated as follows:
-                -   If a policy is in both self.want amd self.have, and they
-                    contain differences, merge self.want into self.have,
-                    with self.want keys taking precedence and append the
-                    merged policy to self.need_update.
-                -   If a policy is in both self.want and self.have, and they
-                    are identical, do not append the policy to self.need_update
-                    (i.e. do nothing).
-        """
-        method_name = inspect.stack()[0][3]
-        msg = f"ENTERED {self.class_name}.{method_name}: "
-        msg += f"state: {self.state}, "
-        msg += f"check_mode: {self.check_mode}"
-        self.log.debug(msg)
-
-        for want in self.want.get("config"):
-            self.have.policy_name = want.get("policyName")
-
-            # Policy does not exist on the controller so needs to be created.
-            if self.have.policy is None:
-                self.need_create.append(copy.deepcopy(want))
-                continue
-
-            # The policy exists on the controller.  Merge want parameters with
-            # the controller's parameters and add the merged parameters to the
-            # need_update list if they differ from the want parameters.
-            have = copy.deepcopy(self.have.policy)
-            merged, needs_update = self._merge_policies(have, want)
-
-            if needs_update is True:
-                self.need_update.append(copy.deepcopy(merged))
-
-    def get_want(self) -> None:
-        """
-        # Summary
-
-        Modify the configurations in self.want["config"] by converting them
-        to payloads to more easily compare them to self.have (the current image
-        policies on the controller).
-
-        # Raises
-
-        `ValueError` if:
-            - `Config2Payload` raises `ValueError`
-        """
-        method_name = inspect.stack()[0][3]
-
-        new_want: dict[Any, Any] = {}
-        new_want["config"] = []
-        for config in self.want.get("config", []):
-            payload = Config2Payload()
-            payload.config = config
-            payload.params = self.rest_send.params  # type: ignore[attr-defined]
-            try:
-                payload.commit()
-            except ValueError as error:
-                msg = f"{self.class_name}.{method_name}: "
-                msg += "Error while converting config to payload. "
-                msg += f"Error detail: {error}"
-                self.log.error(msg)
-                print(msg)
-            new_want["config"].append(payload.payload)
-        self.want = copy.deepcopy(new_want)
-
-    def commit(self) -> None:
-        """
-        Commit the merged state requests
-        """
-        method_name = inspect.stack()[0][3]
-        msg = f"ENTERED {self.class_name}.{method_name}: "
-        msg += f"state: {self.state}, "
-        msg += f"check_mode: {self.check_mode}"
-        self.log.debug(msg)
-
-        if self.rest_send is None:  # type: ignore[attr-defined]
-            msg = f"{self.class_name}.{method_name}: "
-            msg += f"rest_send must be set before calling {method_name}."
-            raise ValueError(msg)
-
-        self.rest_send.results.state = self.state  # type: ignore[attr-defined]
-        self.rest_send.results.check_mode = self.check_mode  # type: ignore[attr-defined]
-
-        self.get_want()
-        self.get_have()
-        self.get_need()
-        self.send_need_create()
-        self.send_need_update()
-
-    def _prepare_for_merge(self, have: dict, want: dict) -> tuple[dict[Any, Any], dict[Any, Any]]:
-        """
-        ### Summary
-        -   Remove fields in "have" that are not part of a request payload i.e.
-            imageName and ref_count.
-        -   The controller returns "N9K/N3K" for the platform, but it expects
-            "N9K" in the payload.  We change "N9K/N3K" to "N9K" in have so that
-            the compare works.
-        -   Remove all fields that are not set in both "have" and "want"
-        """
-        # Remove keys that the controller adds which are not part
-        # of a request payload.
-        for key in ["imageName", "ref_count", "platformPolicies"]:
-            have.pop(key, None)
-
-        # Change "N9K/N3K" to "N9K" in "have" to match the request payload.
-        if have.get("platform", None) == "N9K/N3K":
-            have["platform"] = "N9K"
-
-        return (have, want)
-
-    def _merge_policies(self, have: dict, want: dict) -> tuple[dict[Any, Any], bool]:
-        """
-        ### Summary
-        Merge the parameters in want with the parameters in have.
-        """
-        method_name = inspect.stack()[0][3]
-        (have, want) = self._prepare_for_merge(have, want)
-
-        # Merge the parameters in want with the parameters in have.
-        # The parameters in want take precedence.
-        try:
-            merge = MergeDicts()
-            merge.dict1 = have
-            merge.dict2 = want
-            merge.commit()
-        except (TypeError, ValueError) as error:
-            msg = f"{self.class_name}.{method_name}: "
-            msg += "Error during MergeDicts(). "
-            msg += f"Error detail: {error}"
-            raise ValueError(msg) from error
-        merged = copy.deepcopy(merge.dict_merged)
-
-        needs_update = False
-
-        if have != merged:
-            needs_update = True
-
-        return (merged, needs_update)
-
-    def send_need_create(self) -> None:
-        """
-        ### Summary
-        Create the policies in self.need_create
-
-        """
-        self.create.results = self.rest_send.results  # type: ignore[attr-defined]
-        self.create.payloads = self.need_create
-        self.create.rest_send = self.rest_send  # type: ignore[attr-defined]
-        self.create.params = self.rest_send.params  # type: ignore[attr-defined]
-        self.create.commit()
-
-    def send_need_update(self) -> None:
-        """
-        ### Summary
-        Update the policies in self.need_update
-
-        """
-        self.update.results = self.rest_send.results  # type: ignore[attr-defined]
-        self.update.payloads = self.need_update
-        self.update.rest_send = self.rest_send  # type: ignore[attr-defined]
-        self.update.params = self.rest_send.params  # type: ignore[attr-defined]
-        self.update.commit()
-
-    @property
-    def want(self) -> dict:
-        """
-        ### Summary
-        Return the playbook configuration.
-
-        ### Returns
-        -   list: The playbook configuration.
-        """
-        return self._want
-
-    @want.setter
-    def want(self, value: dict):
-        """
-        ### Summary
-        Set the playbook configuration.
-
-        ### Parameters
-        -   value: The playbook configuration.
-        """
-        self._want = value
 
 
 def setup_parser() -> argparse.Namespace:
@@ -374,18 +111,17 @@ def main():
     params = {}
     params["check_mode"] = False
     params["state"] = "merged"
+    params["config"] = json.loads(validated_config.model_dump_json())
+
     rest_send = RestSend(params)
     rest_send.send_interval = 3
     rest_send.timeout = 9
     rest_send.sender = ndfc_sender.sender
     rest_send.response_handler = ResponseHandler()
-    rest_send.results = Results()
 
     try:
         task = Merged(params)
-        # pylint: disable=attribute-defined-outside-init
-        task.rest_send = rest_send  # type: ignore[attr-defined]
-        task.want = json.loads(validated_config.model_dump_json())
+        task.rest_send = rest_send
         task.commit()
     except ValueError as error:
         err_msg = f"Exiting.  Error detail: {error}"
@@ -393,13 +129,13 @@ def main():
         print(err_msg)
         sys.exit(1)
 
-    task.rest_send.results.build_final_result()  # type: ignore[attr-defined]
+    task.results.build_final_result()
     # pylint: disable=unsupported-membership-test
-    if True in task.rest_send.results.failed:  # type: ignore[attr-defined]
+    if True in task.results.failed:
         err_msg = "unable to create/update image policies"
         log.error(err_msg)
         print(err_msg)
-    print(json.dumps(task.rest_send.results.final_result, indent=4, sort_keys=True))  # type: ignore[attr-defined]
+    print(json.dumps(task.results.final_result, indent=4, sort_keys=True))
 
 
 if __name__ == "__main__":

--- a/examples/image_policy_delete.py
+++ b/examples/image_policy_delete.py
@@ -20,13 +20,11 @@ __metaclass__ = type
 __author__ = "Allen Robel"
 
 import argparse
-import copy
-import inspect
 import json
 import logging
 import sys
-from typing import Any
 
+from ndfc_python.image_policy import Deleted
 from ndfc_python.ndfc_python_logger import NdfcPythonLogger
 from ndfc_python.ndfc_python_sender import NdfcPythonSender
 from ndfc_python.parsers.parser_ansible_vault import parser_ansible_vault
@@ -40,136 +38,9 @@ from ndfc_python.parsers.parser_nxos_password import parser_nxos_password
 from ndfc_python.parsers.parser_nxos_username import parser_nxos_username
 from ndfc_python.read_config import ReadConfig
 from ndfc_python.validators.image_policy_delete import ImagePolicyDeleteConfigValidator
-from plugins.module_utils.common.properties import Properties
 from plugins.module_utils.common.response_handler import ResponseHandler
 from plugins.module_utils.common.rest_send_v2 import RestSend
-from plugins.module_utils.common.results import Results
-from plugins.module_utils.image_policy.delete import ImagePolicyDelete
-from plugins.module_utils.image_policy.payload import Config2Payload
 from pydantic import ValidationError
-
-
-@Properties.add_rest_send
-class Deleted:
-    """
-    Handle deleted state
-    """
-
-    def __init__(self):
-        self.class_name = self.__class__.__name__
-        self.log = logging.getLogger(f"ndfc_python.{self.class_name}")
-
-        method_name = inspect.stack()[0][3]
-
-        self.state = "deleted"
-        self.check_mode = False
-
-        self.delete = ImagePolicyDelete()
-
-        msg = f"ENTERED {self.class_name}().{method_name}: "
-        msg += f"state: {self.state}, "
-        msg += f"check_mode: {self.check_mode}"
-        self.log.debug(msg)
-
-    def get_want(self) -> None:
-        """
-        # Summary
-
-        Modify the configurations in self.want["config"] by converting them
-        to payloads to more easily compare them to self.have (the current image
-        policies on the controller).
-
-        # Raises
-
-        `ValueError` if:
-            - `Config2Payload` raises `ValueError`
-        """
-        method_name = inspect.stack()[0][3]
-
-        new_want: dict[Any, Any] = {}
-        new_want["config"] = []
-        for config in self.want.get("config", []):
-            payload = Config2Payload()
-            payload.config = config
-            payload.params = self.rest_send.params  # type: ignore[attr-defined]
-            try:
-                payload.commit()
-            except ValueError as error:
-                msg = f"{self.class_name}.{method_name}: "
-                msg += "Error while converting config to payload. "
-                msg += f"Error detail: {error}"
-                self.log.error(msg)
-                print(msg)
-            new_want["config"].append(payload.payload)
-        self.want = copy.deepcopy(new_want)
-
-    def commit(self) -> None:
-        """
-        If config is present, delete all policies in self.want that exist on the controller
-        If config is not present, delete all policies on the controller
-        """
-        method_name = inspect.stack()[0][3]
-        msg = f"ENTERED {self.class_name}.{method_name}: "
-        msg += f"state: {self.state}, "
-        msg += f"check_mode: {self.check_mode}"
-        self.log.debug(msg)
-
-        if self.rest_send is None:  # type: ignore[attr-defined]
-            msg = f"{self.class_name}.{method_name}: "
-            msg += f"rest_send must be set before calling {method_name}."
-            raise ValueError(msg)
-
-        self.rest_send.params["state"] = self.state  # type: ignore[attr-defined]
-        self.rest_send.results.state = self.state  # type: ignore[attr-defined]
-        self.rest_send.results.check_mode = self.check_mode  # type: ignore[attr-defined]
-
-        self.rest_send.results.state = self.state  # type: ignore[attr-defined]
-        self.rest_send.results.check_mode = self.check_mode  # type: ignore[attr-defined]
-        self.delete.policy_names = self.get_policies_to_delete()
-        self.delete.results = self.rest_send.results  # type: ignore[attr-defined]
-        self.delete.rest_send = self.rest_send  # type: ignore[attr-defined]
-        self.delete.params = self.rest_send.params  # type: ignore[attr-defined]
-        self.delete.commit()
-
-    def get_policies_to_delete(self) -> list[str]:
-        """
-        Return a list of policy names to delete
-
-        -   In config is present, return list of image policy names
-            in self.want.
-        -   If want["config"] is not present, return ["delete_all_image_policies"],
-            which ``ImagePolicyDelete()`` interprets as "delete all image
-            policies on the controller".
-        """
-        if self.want.get("config") is None:
-            return ["delete_all_image_policies"]
-        self.get_want()
-        policy_names_to_delete = []
-        for want in self.want.get("config", {}):
-            policy_names_to_delete.append(want["policyName"])
-        return policy_names_to_delete
-
-    @property
-    def want(self) -> dict:
-        """
-        ### Summary
-        Return the playbook configuration.
-
-        ### Returns
-        -   list: The playbook configuration.
-        """
-        return self._want
-
-    @want.setter
-    def want(self, value: dict):
-        """
-        ### Summary
-        Set the playbook configuration.
-
-        ### Parameters
-        -   value: The playbook configuration.
-        """
-        self._want = value
 
 
 def setup_parser() -> argparse.Namespace:
@@ -240,18 +111,18 @@ def main():
     params = {}
     params["check_mode"] = False
     params["state"] = "deleted"
+    params["config"] = json.loads(validated_config.model_dump_json())
+
     rest_send = RestSend(params)
     rest_send.send_interval = 3
     rest_send.timeout = 9
     rest_send.sender = ndfc_sender.sender
     rest_send.response_handler = ResponseHandler()
-    rest_send.results = Results()
 
     try:
-        task = Deleted()
+        task = Deleted(params)
         # pylint: disable=attribute-defined-outside-init
         task.rest_send = rest_send  # type: ignore[attr-defined]
-        task.want = json.loads(validated_config.model_dump_json())
         task.commit()
     except ValueError as error:
         err_msg = f"Exiting.  Error detail: {error}"
@@ -259,13 +130,13 @@ def main():
         print(err_msg)
         sys.exit(1)
 
-    task.rest_send.results.build_final_result()  # type: ignore[attr-defined]
+    task.results.build_final_result()
     # pylint: disable=unsupported-membership-test
-    if True in task.rest_send.results.failed:  # type: ignore[attr-defined]
+    if True in task.results.failed:
         err_msg = "unable to delete image policies"
         log.error(err_msg)
         print(err_msg)
-    print(json.dumps(task.rest_send.results.final_result, indent=4, sort_keys=True))  # type: ignore[attr-defined]
+    print(json.dumps(task.results.final_result, indent=4, sort_keys=True))
 
 
 if __name__ == "__main__":

--- a/examples/image_policy_info.py
+++ b/examples/image_policy_info.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
 
 import argparse
-import inspect
 import json
 import logging
 import sys
 
+from ndfc_python.image_policy import Query
 from ndfc_python.ndfc_python_logger import NdfcPythonLogger
 from ndfc_python.ndfc_python_sender import NdfcPythonSender
 from ndfc_python.parsers.parser_ansible_vault import parser_ansible_vault
@@ -19,102 +19,9 @@ from ndfc_python.parsers.parser_nxos_password import parser_nxos_password
 from ndfc_python.parsers.parser_nxos_username import parser_nxos_username
 from ndfc_python.read_config import ReadConfig
 from ndfc_python.validators.image_policy_info import ImagePolicyInfoConfigValidator
-from plugins.module_utils.common.properties import Properties
 from plugins.module_utils.common.response_handler import ResponseHandler
 from plugins.module_utils.common.rest_send_v2 import RestSend
-from plugins.module_utils.common.results import Results
-from plugins.module_utils.image_policy.image_policies import ImagePolicies
-from plugins.module_utils.image_policy.query import ImagePolicyQuery
 from pydantic import ValidationError
-
-
-@Properties.add_rest_send
-class Query:
-    """
-    Handle query state
-    """
-
-    def __init__(self):
-        self.class_name = self.__class__.__name__
-        method_name = inspect.stack()[0][3]
-        self.state = "query"
-        self.check_mode = False
-
-        self.log = logging.getLogger(f"dcnm.{self.class_name}")
-        self.image_policies = None
-        self.query = None
-        self._rest_send = None
-
-        msg = f"ENTERED {self.class_name}().{method_name}: "
-        msg += f"check_mode: {self.check_mode}"
-        self.log.debug(msg)
-
-    def commit(self) -> None:
-        """
-        1.  query the fabrics in self.want that exist on the controller
-        """
-        method_name = inspect.stack()[0][3]
-        msg = f"ENTERED {self.class_name}.{method_name}: "
-        msg += f"check_mode: {self.check_mode}"
-        self.log.debug(msg)
-
-        if self._rest_send is None:
-            msg = f"{self.class_name}.{method_name}: "
-            msg += "Set rest_send before calling commit."
-            raise ValueError(msg)
-
-        if self.want is None:
-            msg = f"{self.class_name}.{method_name}: "
-            msg += "Set want before calling commit."
-            raise ValueError(msg)
-
-        if len(self.want) == 0:
-            msg = f"{self.class_name}.{method_name}: "
-            msg += "Nothing to query."
-            print("msg")
-            return
-
-        policy_names_to_query = set()
-        for want in self.want:
-            policy_names_to_query.add(want["name"])
-
-        self.image_policies = ImagePolicies()
-        self.image_policies.rest_send = self._rest_send
-        self.image_policies.results = self._rest_send.results
-
-        params = {}
-        params["check_mode"] = self.check_mode
-        params["state"] = self.state
-
-        self.query = ImagePolicyQuery()
-        self.query.params = params
-        self.query.results = self._rest_send.results
-        self.query.rest_send = self._rest_send
-        self.query.image_policies = self.image_policies
-        self.query.policy_names = list(policy_names_to_query)
-        self.query.commit()
-
-    @property
-    def want(self):
-        """
-        ### Summary
-        Return the playbook configuration.
-
-        ### Returns
-        -   list: The playbook configuration.
-        """
-        return self._want
-
-    @want.setter
-    def want(self, value):
-        """
-        ### Summary
-        Set the playbook configuration.
-
-        ### Parameters
-        -   value: The playbook configuration.
-        """
-        self._want = value
 
 
 def setup_parser() -> argparse.Namespace:
@@ -165,7 +72,7 @@ def main():
         sys.exit(1)
 
     try:
-        ImagePolicyInfoConfigValidator(**ndfc_config.contents)
+        validated_config = ImagePolicyInfoConfigValidator(**ndfc_config.contents)
     except ValidationError as error:
         err_msg = f"{error}"
         log.error(err_msg)
@@ -182,16 +89,18 @@ def main():
         print(err_msg)
         sys.exit(1)
 
+    params = {}
+    params["check_mode"] = False
+    params["state"] = "query"
+    params["config"] = json.loads(validated_config.model_dump_json())
+
     rest_send = RestSend({})
     rest_send.sender = ndfc_sender.sender
     rest_send.response_handler = ResponseHandler()
-    rest_send.results = Results()
 
     try:
-        task = Query()
-        # pylint: disable=attribute-defined-outside-init
-        task.rest_send = rest_send  # type: ignore[attr-defined]
-        task.want = ndfc_config.contents["config"]
+        task = Query(params)
+        task.rest_send = rest_send
         task.commit()
     except ValueError as error:
         err_msg = f"Exiting.  Error detail: {error}"
@@ -199,13 +108,13 @@ def main():
         print(err_msg)
         sys.exit(1)
 
-    task.rest_send.results.build_final_result()  # type: ignore[attr-defined]
+    task.results.build_final_result()
     # pylint: disable=unsupported-membership-test
-    if True in task.rest_send.results.failed:  # type: ignore[attr-defined]
+    if True in task.results.failed:
         err_msg = "unable to query image policies"
         log.error(err_msg)
         print(err_msg)
-    print(json.dumps(task.rest_send.results.final_result, indent=4, sort_keys=True))  # type: ignore[attr-defined]
+    print(json.dumps(task.results.final_result, indent=4, sort_keys=True))
 
 
 if __name__ == "__main__":

--- a/examples/image_policy_override.py
+++ b/examples/image_policy_override.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2024 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# pylint: disable=wrong-import-position
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+__author__ = "Allen Robel"
+
+import argparse
+import json
+import logging
+import sys
+
+from ndfc_python.image_policy import Overridden
+from ndfc_python.ndfc_python_logger import NdfcPythonLogger
+from ndfc_python.ndfc_python_sender import NdfcPythonSender
+from ndfc_python.parsers.parser_ansible_vault import parser_ansible_vault
+from ndfc_python.parsers.parser_config import parser_config
+from ndfc_python.parsers.parser_loglevel import parser_loglevel
+from ndfc_python.parsers.parser_nd_domain import parser_nd_domain
+from ndfc_python.parsers.parser_nd_ip4 import parser_nd_ip4
+from ndfc_python.parsers.parser_nd_password import parser_nd_password
+from ndfc_python.parsers.parser_nd_username import parser_nd_username
+from ndfc_python.parsers.parser_nxos_password import parser_nxos_password
+from ndfc_python.parsers.parser_nxos_username import parser_nxos_username
+from ndfc_python.read_config import ReadConfig
+from ndfc_python.validators.image_policy_create import ImagePolicyCreateConfigValidator
+from plugins.module_utils.common.response_handler import ResponseHandler
+from plugins.module_utils.common.rest_send_v2 import RestSend
+from pydantic import ValidationError
+
+
+def setup_parser() -> argparse.Namespace:
+    """
+    ### Summary
+
+    Setup script-specific parser
+
+    Returns:
+        argparse.Namespace
+    """
+    description = "DESCRIPTION: "
+    description += "Create/update image policies on one or more switches."
+    parser = argparse.ArgumentParser(
+        parents=[
+            parser_ansible_vault,
+            parser_config,
+            parser_loglevel,
+            parser_nd_domain,
+            parser_nd_ip4,
+            parser_nd_password,
+            parser_nd_username,
+            parser_nxos_password,
+            parser_nxos_username,
+        ],
+        description=description,
+    )
+    return parser.parse_args()
+
+
+def main():
+    """
+    main entry point for module execution
+    """
+    args = setup_parser()
+    NdfcPythonLogger()
+    log = logging.getLogger("ndfc_python.main")
+    log.setLevel = args.loglevel
+
+    try:
+        ndfc_config = ReadConfig()
+        ndfc_config.filename = args.config
+        ndfc_config.commit()
+    except ValueError as error:
+        err_msg = f"Exiting: Error detail: {error}"
+        log.error(err_msg)
+        print(err_msg)
+        sys.exit(1)
+
+    try:
+        validated_config = ImagePolicyCreateConfigValidator(**ndfc_config.contents)
+    except ValidationError as error:
+        err_msg = f"{error}"
+        log.error(err_msg)
+        print(err_msg)
+        sys.exit(1)
+
+    try:
+        ndfc_sender = NdfcPythonSender()
+        ndfc_sender.args = args
+        ndfc_sender.commit()
+    except ValueError as error:
+        err_msg = f"Exiting.  Error detail: {error}"
+        log.error(err_msg)
+        print(err_msg)
+        sys.exit(1)
+
+    params = {}
+    params["check_mode"] = False
+    params["state"] = "overridden"
+    params["config"] = json.loads(validated_config.model_dump_json())
+
+    rest_send = RestSend(params)
+    rest_send.send_interval = 3
+    rest_send.timeout = 9
+    rest_send.sender = ndfc_sender.sender
+    rest_send.response_handler = ResponseHandler()
+
+    try:
+        task = Overridden(params)
+        task.rest_send = rest_send
+        task.commit()
+    except ValueError as error:
+        err_msg = f"Exiting.  Error detail: {error}"
+        log.error(err_msg)
+        print(err_msg)
+        sys.exit(1)
+
+    task.results.build_final_result()
+    # pylint: disable=unsupported-membership-test
+    if True in task.results.failed:
+        err_msg = "unable to override one or more image policies"
+        log.error(err_msg)
+        print(err_msg)
+    print(json.dumps(task.results.final_result, indent=4, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/image_policy_replace.py
+++ b/examples/image_policy_replace.py
@@ -20,13 +20,11 @@ __metaclass__ = type
 __author__ = "Allen Robel"
 
 import argparse
-import copy
-import inspect
 import json
 import logging
 import sys
-from typing import Any
 
+from ndfc_python.image_policy import Replaced
 from ndfc_python.ndfc_python_logger import NdfcPythonLogger
 from ndfc_python.ndfc_python_sender import NdfcPythonSender
 from ndfc_python.parsers.parser_ansible_vault import parser_ansible_vault
@@ -40,142 +38,9 @@ from ndfc_python.parsers.parser_nxos_password import parser_nxos_password
 from ndfc_python.parsers.parser_nxos_username import parser_nxos_username
 from ndfc_python.read_config import ReadConfig
 from ndfc_python.validators.image_policy_create import ImagePolicyCreateConfigValidator
-from plugins.module_utils.common.properties import Properties
 from plugins.module_utils.common.response_handler import ResponseHandler
 from plugins.module_utils.common.rest_send_v2 import RestSend
-from plugins.module_utils.common.results import Results
-from plugins.module_utils.image_policy.image_policies import ImagePolicies
-from plugins.module_utils.image_policy.payload import Config2Payload
-from plugins.module_utils.image_policy.replace import ImagePolicyReplaceBulk
 from pydantic import ValidationError
-
-
-@Properties.add_rest_send
-class Replaced:
-    """
-    Replace any policies on the controller that are in the config file with
-    the configuration given in the config file.  Policies not listed in the
-    config file are not modified and are not deleted.
-    """
-
-    def __init__(self, params) -> None:
-        self.class_name = self.__class__.__name__
-        self.log = logging.getLogger(f"ndfc_python.{self.class_name}")
-
-        method_name = inspect.stack()[0][3]
-
-        self._rest_send = None
-        self.have = ImagePolicies()
-        self.need: list[dict[Any, Any]] = []
-        self._want: dict[Any, Any] = {}
-
-        self.state = "replaced"
-        self.check_mode = params.get("check_mode")
-
-        self.replace = ImagePolicyReplaceBulk()
-
-        msg = f"ENTERED {self.class_name}().{method_name}: "
-        msg += f"state: {self.state}, "
-        msg += f"check_mode: {self.check_mode}"
-        self.log.debug(msg)
-
-    def get_have(self) -> None:
-        """
-        Caller: main()
-
-        self.have consists of the current image policies on the controller
-        """
-        method_name = inspect.stack()[0][3]
-        msg = f"ENTERED {self.class_name}.{method_name}"
-        self.log.debug(msg)
-
-        self.have = ImagePolicies()
-        # pylint: disable=no-member
-        self.have.results = self.rest_send.results  # type: ignore[attr-defined]
-        self.have.rest_send = self.rest_send  # type: ignore[attr-defined]
-        self.have.refresh()
-        # pylint: enable=no-member
-
-    def get_want(self) -> None:
-        """
-        # Summary
-
-        Modify the configurations in self.want["config"] by converting them
-        to payloads to more easily compare them to self.have (the current image
-        policies on the controller).
-
-        # Raises
-
-        `ValueError` if:
-            - `Config2Payload` raises `ValueError`
-        """
-        method_name = inspect.stack()[0][3]
-
-        new_want: dict[Any, Any] = {}
-        new_want["config"] = []
-        for config in self.want.get("config", []):
-            payload = Config2Payload()
-            payload.config = config
-            payload.params = self.rest_send.params  # type: ignore[attr-defined]
-            try:
-                payload.commit()
-            except ValueError as error:
-                msg = f"{self.class_name}.{method_name}: "
-                msg += "Error while converting config to payload. "
-                msg += f"Error detail: {error}"
-                self.log.error(msg)
-                print(msg)
-            new_want["config"].append(payload.payload)
-        self.want = copy.deepcopy(new_want)
-
-    def commit(self) -> None:
-        """
-        Replace all policies on the controller that are in want
-        """
-        method_name = inspect.stack()[0][3]
-        msg = f"ENTERED {self.class_name}.{method_name}: "
-        msg += f"state: {self.state}, "
-        msg += f"check_mode: {self.check_mode}"
-        self.log.debug(msg)
-
-        if self.rest_send is None:  # type: ignore[attr-defined]
-            msg = f"{self.class_name}.{method_name}: "
-            msg += f"rest_send must be set before calling {method_name}."
-            raise ValueError(msg)
-
-        self.rest_send.results.state = self.state  # type: ignore[attr-defined]
-        self.rest_send.results.check_mode = self.check_mode  # type: ignore[attr-defined]
-
-        self.get_want()
-        self.get_have()
-
-        self.replace.results = self.rest_send.results  # type: ignore[attr-defined]
-        self.replace.payloads = self.want.get("config")
-        self.replace.rest_send = self.rest_send  # type: ignore[attr-defined]
-        self.replace.params = self.rest_send.params  # type: ignore[attr-defined]
-        self.replace.commit()
-
-    @property
-    def want(self) -> dict:
-        """
-        ### Summary
-        Return the playbook configuration.
-
-        ### Returns
-        -   list: The playbook configuration.
-        """
-        return self._want
-
-    @want.setter
-    def want(self, value: dict):
-        """
-        ### Summary
-        Set the playbook configuration.
-
-        ### Parameters
-        -   value: The playbook configuration.
-        """
-        self._want = value
 
 
 def setup_parser() -> argparse.Namespace:
@@ -248,18 +113,17 @@ def main():
     params = {}
     params["check_mode"] = False
     params["state"] = "replaced"
+    params["config"] = json.loads(validated_config.model_dump_json())
+
     rest_send = RestSend(params)
     rest_send.send_interval = 3
     rest_send.timeout = 9
     rest_send.sender = ndfc_sender.sender
     rest_send.response_handler = ResponseHandler()
-    rest_send.results = Results()
 
     try:
         task = Replaced(params)
-        # pylint: disable=attribute-defined-outside-init
-        task.rest_send = rest_send  # type: ignore[attr-defined]
-        task.want = json.loads(validated_config.model_dump_json())
+        task.rest_send = rest_send
         task.commit()
     except ValueError as error:
         err_msg = f"Exiting.  Error detail: {error}"
@@ -267,13 +131,13 @@ def main():
         print(err_msg)
         sys.exit(1)
 
-    task.rest_send.results.build_final_result()  # type: ignore[attr-defined]
+    task.results.build_final_result()
     # pylint: disable=unsupported-membership-test
-    if True in task.rest_send.results.failed:  # type: ignore[attr-defined]
+    if True in task.results.failed:
         err_msg = "unable to replace image policy configuration(s)"
         log.error(err_msg)
         print(err_msg)
-    print(json.dumps(task.rest_send.results.final_result, indent=4, sort_keys=True))  # type: ignore[attr-defined]
+    print(json.dumps(task.results.final_result, indent=4, sort_keys=True))
 
 
 if __name__ == "__main__":

--- a/lib/ndfc_python/image_policy.py
+++ b/lib/ndfc_python/image_policy.py
@@ -1,0 +1,618 @@
+import copy
+import inspect
+import json
+import logging
+from typing import Any
+
+from plugins.module_utils.common.merge_dicts_v2 import MergeDicts
+from plugins.module_utils.common.properties import Properties
+from plugins.module_utils.common.results import Results
+from plugins.module_utils.image_policy.create import ImagePolicyCreateBulk
+from plugins.module_utils.image_policy.delete import ImagePolicyDelete
+from plugins.module_utils.image_policy.image_policies import ImagePolicies
+from plugins.module_utils.image_policy.payload import Config2Payload
+from plugins.module_utils.image_policy.query import ImagePolicyQuery
+from plugins.module_utils.image_policy.replace import ImagePolicyReplaceBulk
+from plugins.module_utils.image_policy.update import ImagePolicyUpdateBulk
+
+
+@Properties.add_rest_send
+class Common:
+    """
+    Common methods for all states
+    """
+
+    def __init__(self, params) -> None:
+        self.class_name = self.__class__.__name__
+        method_name = inspect.stack()[0][3]
+
+        self.log = logging.getLogger(f"dcnm.{self.class_name}")
+        self.params: dict[Any, Any] = params
+
+        self.state = self.params.get("state", None)
+        self.check_mode = self.params.get("check_mode", None)
+
+        if self.state not in ["deleted", "merged", "overridden", "query", "replaced"]:
+            msg = f"{self.class_name}.{method_name}: "
+            msg += f"Invalid state ({self.state}) in params."
+            raise ValueError(msg)
+
+        if self.check_mode not in [False, True]:
+            msg = f"{self.class_name}.{method_name}: "
+            msg += f"Invalid check_mode ({self.check_mode}) in params."
+            raise ValueError(msg)
+
+        self.config = self.params.get("config", {}).get("config", None)
+
+        msg = f"{self.class_name}.{method_name}: "
+        msg += f"self.config: {self.config}"
+        self.log.debug(msg)
+
+        self.results = Results()
+        self.results.check_mode = self.check_mode
+
+        self._rest_send = None
+
+        self.want: list[Any] = []
+        self.have = ImagePolicies()
+
+        msg = f"ENTERED {self.class_name}().{method_name}: "
+        msg += f"check_mode: {self.check_mode}"
+        self.log.debug(msg)
+
+    def get_want(self) -> None:
+        """
+        # Summary
+
+        Modify the configurations in self.want["config"] by converting them
+        to payloads to more easily compare them to self.have (the current image
+        policies on the controller).
+
+        # Raises
+
+        `ValueError` if:
+            - `Config2Payload` raises `ValueError`
+        """
+        method_name = inspect.stack()[0][3]
+
+        for config in self.config:
+            payload = Config2Payload()
+            payload.config = config
+            payload.params = self.params
+            try:
+                payload.commit()
+            except ValueError as error:
+                msg = f"{self.class_name}.{method_name}: "
+                msg += "Error while converting config to payload. "
+                msg += f"Error detail: {error}"
+                self.log.error(msg)
+                print(msg)
+            self.want.append(payload.payload)
+
+    def get_have(self) -> None:
+        """
+        Caller: main()
+
+        self.have consists of the current image policies on the controller
+        """
+        method_name = inspect.stack()[0][3]
+        msg = f"ENTERED {self.class_name}.{method_name}"
+        self.log.debug(msg)
+
+        self.have = ImagePolicies()
+        # pylint: disable=no-member
+        self.have.results = self.results  # type: ignore[attr-defined]
+        self.have.rest_send = self.rest_send  # type: ignore[attr-defined]
+        self.have.refresh()
+        # pylint: enable=no-member
+
+
+class Deleted(Common):
+    """
+    Handle deleted state
+    """
+
+    def __init__(self, params):
+        self.class_name = self.__class__.__name__
+        method_name = inspect.stack()[0][3]
+
+        try:
+            super().__init__(params)
+        except (TypeError, ValueError) as error:
+            msg = f"{self.class_name}.{method_name}: "
+            msg += "Error during super().__init__(). "
+            msg += f"Error detail: {error}"
+            raise ValueError(msg) from error
+
+        if not isinstance(self.config, list):
+            msg = f"{self.class_name}.{method_name}: "
+            msg += "Expected list of dict for params.config. "
+            msg += f"Got {type(self.config).__name__}"
+            raise TypeError(msg)
+
+        self.delete = ImagePolicyDelete()
+
+        msg = f"ENTERED {self.class_name}().{method_name}: "
+        msg += f"state: {self.state}, "
+        msg += f"check_mode: {self.check_mode}"
+        self.log.debug(msg)
+
+    def commit(self) -> None:
+        """
+        If config is present, delete all policies in self.want that exist on the controller
+        If config is not present, delete all policies on the controller
+        """
+        method_name = inspect.stack()[0][3]
+        msg = f"ENTERED {self.class_name}.{method_name}: "
+        msg += f"state: {self.state}, "
+        msg += f"check_mode: {self.check_mode}"
+        self.log.debug(msg)
+
+        # pylint: disable=no-member
+        if self.rest_send is None:  # type: ignore[attr-defined]
+            msg = f"{self.class_name}.{method_name}: "
+            msg += f"rest_send must be set before calling {method_name}."
+            raise ValueError(msg)
+        # pylint: enable=no-member
+
+        self.results.state = self.state
+        self.results.check_mode = self.check_mode
+
+        self.delete.policy_names = self.get_policies_to_delete()
+        self.delete.results = self.results
+        # pylint: disable=no-member
+        self.delete.rest_send = self.rest_send  # type: ignore[attr-defined]
+        # pylint: enable=no-member
+        self.delete.params = self.params
+        self.delete.commit()
+
+    def get_policies_to_delete(self) -> list[str]:
+        """
+        Return a list of policy names to delete
+
+        -   In config is present, return list of image policy names
+            in self.want.
+        -   If want["config"] is not present, return ["delete_all_image_policies"],
+            which ``ImagePolicyDelete()`` interprets as "delete all image
+            policies on the controller".
+        """
+        method_name = inspect.stack()[0][3]
+        msg = f"{self.class_name}.{method_name}: "
+        msg += f"self.config: {self.config}"
+        self.log.debug(msg)
+
+        # if self.config is None:
+        #     return ["delete_all_image_policies"]
+        self.get_want()
+        policy_names_to_delete = []
+        for want in self.want:
+            policy_names_to_delete.append(want["policyName"])
+        return policy_names_to_delete
+
+
+class Overridden(Common):
+    """
+    ### Summary
+    Handle overridden state
+
+    ### Raises
+    -   ``ValueError`` if:
+            -   ``Common().__init__()`` raises ``TypeError`` or ``ValueError``.
+    """
+
+    def __init__(self, params):
+        self.class_name = self.__class__.__name__
+        method_name = inspect.stack()[0][3]
+
+        try:
+            super().__init__(params)
+        except (TypeError, ValueError) as error:
+            msg = f"{self.class_name}.{method_name}: "
+            msg += "Error during super().__init__(). "
+            msg += f"Error detail: {error}"
+            raise ValueError(msg) from error
+
+        if not isinstance(self.config, list):
+            msg = f"{self.class_name}.{method_name}: "
+            msg += "Expected list of dict for params.config. "
+            msg += f"Got {type(self.config).__name__}"
+            raise TypeError(msg)
+
+        self.delete = ImagePolicyDelete()
+        self.merged = Merged(params)
+        self.replaced = Replaced(params)
+
+        msg = f"ENTERED {self.class_name}().{method_name}: "
+        msg += f"state: {self.state}, "
+        msg += f"check_mode: {self.check_mode}"
+        self.log.debug(msg)
+
+    def commit(self) -> None:
+        """
+        ### Summary
+        -   Delete all policies on the controller that are not in self.want
+        -   Instantiate`` Merged()`` and call ``Merged().commit()``
+        """
+        method_name = inspect.stack()[0][3]
+        msg = f"ENTERED {self.class_name}.{method_name}: "
+        msg += f"state: {self.state}, "
+        msg += f"check_mode: {self.check_mode}"
+        self.log.debug(msg)
+
+        self.results.state = self.state
+        self.results.check_mode = self.check_mode
+
+        self.get_want()
+        self.get_have()
+
+        msg = f"{self.class_name}.{method_name}: "
+        msg += "self.want: "
+        msg += f"{json.dumps(self.want, indent=4, sort_keys=True)}"
+        self.log.debug(msg)
+
+        msg = f"{self.class_name}.{method_name}: "
+        msg += "self.have.all_policies: "
+        msg += f"{json.dumps(self.have.all_policies, indent=4, sort_keys=True)}"
+        self.log.debug(msg)
+
+        self._delete_policies_not_in_want()
+        # pylint: disable=no-member
+        # pylint: disable=attribute-defined-outside-init
+        self.replaced.rest_send = self.rest_send  # type: ignore[attr-defined]
+        # pylint: enable=no-member
+        # pylint: enable=attribute-defined-outside-init
+        self.replaced.results = self.results
+        self.replaced.commit()
+
+    def _delete_policies_not_in_want(self) -> None:
+        """
+        ### Summary
+        Delete all policies on the controller that are not in self.want
+        """
+        method_name = inspect.stack()[0][3]
+        want_policy_names = set()
+        for want in self.want:
+            want_policy_names.add(want["policyName"])
+
+        policy_names_to_delete = []
+        for policy_name in self.have.all_policies:
+            msg = f"{self.class_name}.{method_name}: "
+            msg += f"policy_name: {policy_name}"
+            self.log.debug(msg)
+            if policy_name not in want_policy_names:
+                msg = f"{self.class_name}.{method_name}: "
+                msg += f"Appending to policy_names_to_delete: {policy_name}"
+                self.log.debug(msg)
+                policy_names_to_delete.append(policy_name)
+
+        msg = f"{self.class_name}.{method_name}: "
+        msg += f"policy_names_to_delete: {policy_names_to_delete}"
+        self.log.debug(msg)
+
+        if len(policy_names_to_delete) == 0:
+            return
+
+        self.results.state = self.state
+        self.results.check_mode = self.check_mode
+        self.delete.policy_names = policy_names_to_delete
+        self.delete.results = self.results
+        # pylint: disable=no-member
+        self.delete.rest_send = self.rest_send  # type: ignore[attr-defined]
+        # pylint: enable=no-member
+        self.delete.params = self.params
+        self.delete.commit()
+
+
+class Merged(Common):
+    """
+    # Summary
+
+    Handle merged state
+
+    # Raises
+
+    -   ``ValueError`` if:
+        -   ``params`` is missing ``config`` key.
+        -   ``commit()`` is issued before setting mandatory properties
+    """
+
+    def __init__(self, params):
+        self.class_name = self.__class__.__name__
+        method_name = inspect.stack()[0][3]
+
+        try:
+            super().__init__(params)
+        except (TypeError, ValueError) as error:
+            msg = f"{self.class_name}.{method_name}: "
+            msg += "Error during super().__init__(). "
+            msg += f"Error detail: {error}"
+            raise ValueError(msg) from error
+
+        if not isinstance(self.config, list):
+            msg = f"{self.class_name}.{method_name}: "
+            msg += "Expected list of dict for params.config. "
+            msg += f"Got {type(self.config).__name__}"
+            raise TypeError(msg)
+
+        self.create = ImagePolicyCreateBulk()
+        self.update = ImagePolicyUpdateBulk()
+
+        # new policies to be created
+        self.need_create = []
+        # existing policies to be updated
+        self.need_update = []
+
+        self.need = []
+        self.state = "merged"
+
+        msg = f"ENTERED {self.class_name}().{method_name}: "
+        msg += f"state: {self.state}, "
+        msg += f"check_mode: {self.check_mode}"
+        self.log.debug(msg)
+
+    def get_need(self):
+        """
+        # Summary
+
+        Build self.need for merged state
+
+        # Description
+
+        -   Populate self.need_create with items from self.want that are
+            not in self.have
+        -   Populate self.need_update with updated policies.  Policies are
+            updated as follows:
+                -   If a policy is in both self.want amd self.have, and they
+                    contain differences, merge self.want into self.have,
+                    with self.want keys taking precedence and append the
+                    merged policy to self.need_update.
+                -   If a policy is in both self.want and self.have, and they
+                    are identical, do not append the policy to self.need_update
+                    (i.e. do nothing).
+        """
+        method_name = inspect.stack()[0][3]
+        msg = f"ENTERED {self.class_name}.{method_name}: "
+        msg += f"state: {self.state}, "
+        msg += f"check_mode: {self.check_mode}"
+        self.log.debug(msg)
+
+        for want in self.want:
+            self.have.policy_name = want.get("policyName")
+
+            # Policy does not exist on the controller so needs to be created.
+            if self.have.policy is None:
+                self.need_create.append(copy.deepcopy(want))
+                continue
+
+            # The policy exists on the controller.  Merge want parameters with
+            # the controller's parameters and add the merged parameters to the
+            # need_update list if they differ from the want parameters.
+            have = copy.deepcopy(self.have.policy)
+            merged, needs_update = self._merge_policies(have, want)
+
+            if needs_update is True:
+                self.need_update.append(copy.deepcopy(merged))
+
+    def commit(self) -> None:
+        """
+        Commit the merged state requests
+        """
+        method_name = inspect.stack()[0][3]
+        msg = f"ENTERED {self.class_name}.{method_name}: "
+        msg += f"state: {self.state}, "
+        msg += f"check_mode: {self.check_mode}"
+        self.log.debug(msg)
+
+        # pylint: disable=no-member
+        if self.rest_send is None:  # type: ignore[attr-defined]
+            msg = f"{self.class_name}.{method_name}: "
+            msg += f"rest_send must be set before calling {method_name}."
+            raise ValueError(msg)
+        # pylint: enable=no-member
+
+        self.results.state = self.state
+        self.results.check_mode = self.check_mode
+
+        self.get_want()
+        self.get_have()
+        self.get_need()
+        self.send_need_create()
+        self.send_need_update()
+
+    def _prepare_for_merge(self, have: dict, want: dict) -> tuple[dict[Any, Any], dict[Any, Any]]:
+        """
+        ### Summary
+        -   Remove fields in "have" that are not part of a request payload i.e.
+            imageName and ref_count.
+        -   The controller returns "N9K/N3K" for the platform, but it expects
+            "N9K" in the payload.  We change "N9K/N3K" to "N9K" in have so that
+            the compare works.
+        -   Remove all fields that are not set in both "have" and "want"
+        """
+        # Remove keys that the controller adds which are not part
+        # of a request payload.
+        for key in ["imageName", "ref_count", "platformPolicies"]:
+            have.pop(key, None)
+
+        # Change "N9K/N3K" to "N9K" in "have" to match the request payload.
+        if have.get("platform", None) == "N9K/N3K":
+            have["platform"] = "N9K"
+
+        return (have, want)
+
+    def _merge_policies(self, have: dict, want: dict) -> tuple[dict[Any, Any], bool]:
+        """
+        ### Summary
+        Merge the parameters in want with the parameters in have.
+        """
+        method_name = inspect.stack()[0][3]
+        (have, want) = self._prepare_for_merge(have, want)
+
+        # Merge the parameters in want with the parameters in have.
+        # The parameters in want take precedence.
+        try:
+            merge = MergeDicts()
+            merge.dict1 = have
+            merge.dict2 = want
+            merge.commit()
+        except (TypeError, ValueError) as error:
+            msg = f"{self.class_name}.{method_name}: "
+            msg += "Error during MergeDicts(). "
+            msg += f"Error detail: {error}"
+            raise ValueError(msg) from error
+        merged = copy.deepcopy(merge.dict_merged)
+
+        needs_update = False
+
+        if have != merged:
+            needs_update = True
+
+        return (merged, needs_update)
+
+    def send_need_create(self) -> None:
+        """
+        ### Summary
+        Create the policies in self.need_create
+
+        """
+        self.create.results = self.results
+        self.create.payloads = self.need_create
+        # pylint: disable=no-member
+        self.create.rest_send = self.rest_send  # type: ignore[attr-defined]
+        # pylint: enable=no-member
+        self.create.params = self.params
+        self.create.commit()
+
+    def send_need_update(self) -> None:
+        """
+        ### Summary
+        Update the policies in self.need_update
+
+        """
+        self.update.results = self.results
+        self.update.payloads = self.need_update
+        # pylint: disable=no-member
+        self.update.rest_send = self.rest_send  # type: ignore[attr-defined]
+        # pylint: enable=no-member
+        self.update.params = self.params
+        self.update.commit()
+
+
+class Query(Common):
+    """
+    Handle query state
+    """
+
+    def __init__(self, params):
+        self.class_name = self.__class__.__name__
+        method_name = inspect.stack()[0][3]
+
+        try:
+            super().__init__(params)
+        except (TypeError, ValueError) as error:
+            msg = f"{self.class_name}.{method_name}: "
+            msg += "Error during super().__init__(). "
+            msg += f"Error detail: {error}"
+            raise ValueError(msg) from error
+
+        if not isinstance(self.config, list):
+            msg = f"{self.class_name}.{method_name}: "
+            msg += "Expected list of dict for params.config. "
+            msg += f"Got {type(self.config).__name__}"
+            raise TypeError(msg)
+
+        self.image_policies = None
+        self.query = None
+
+        msg = f"ENTERED {self.class_name}().{method_name}: "
+        msg += f"state: {self.state}, "
+        msg += f"check_mode: {self.check_mode}"
+        self.log.debug(msg)
+
+    def commit(self) -> None:
+        """
+        query the fabrics in self.want that exist on the controller
+        """
+        method_name = inspect.stack()[0][3]
+        msg = f"ENTERED {self.class_name}.{method_name}: "
+        msg += f"state: {self.state}, "
+        msg += f"check_mode: {self.check_mode}"
+        self.log.debug(msg)
+
+        self.results.state = self.state
+        self.results.check_mode = self.check_mode
+
+        self.get_want()
+
+        if len(self.want) == 0:
+            msg = f"{self.class_name}.{method_name}: "
+            msg += "Nothing to query."
+            print("msg")
+            return
+
+        policy_names_to_query = set()
+        for want in self.want:
+            policy_names_to_query.add(want["policyName"])
+
+        self.image_policies = ImagePolicies()
+        # pylint: disable=no-member
+        self.image_policies.rest_send = self.rest_send  # type: ignore[attr-defined]
+        # pylint: enable=no-member
+        self.image_policies.results = self.results
+
+        self.query = ImagePolicyQuery()
+        self.query.image_policies = self.image_policies
+        self.query.params = self.params
+        self.query.policy_names = list(policy_names_to_query)
+        # pylint: disable=no-member
+        self.query.rest_send = self.rest_send  # type: ignore[attr-defined]
+        # pylint: enable=no-member
+        self.query.results = self.results
+        self.query.commit()
+
+
+class Replaced(Common):
+    """
+    Handle replaced state
+    """
+
+    def __init__(self, params):
+        self.class_name = self.__class__.__name__
+        method_name = inspect.stack()[0][3]
+
+        try:
+            super().__init__(params)
+        except (TypeError, ValueError) as error:
+            msg = f"{self.class_name}.{method_name}: "
+            msg += "Error during super().__init__(). "
+            msg += f"Error detail: {error}"
+            raise ValueError(msg) from error
+
+        if not isinstance(self.config, list):
+            msg = f"{self.class_name}.{method_name}: "
+            msg += "Expected list of dict for params.config. "
+            msg += f"Got {type(self.config).__name__}"
+            raise TypeError(msg)
+
+        self.replace = ImagePolicyReplaceBulk()
+
+        msg = f"ENTERED {self.class_name}().{method_name}: "
+        msg += f"state: {self.state}, "
+        msg += f"check_mode: {self.check_mode}"
+        self.log.debug(msg)
+
+    def commit(self) -> None:
+        """
+        Replace all policies on the controller that are in want
+        """
+        self.results.state = self.state
+        self.results.check_mode = self.check_mode
+
+        self.get_want()
+        self.get_have()
+
+        self.replace.params = self.params
+        self.replace.payloads = self.want
+        self.replace.rest_send = self.rest_send  # type: ignore[attr-defined]
+        self.replace.results = self.results
+        self.replace.commit()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -84,6 +84,7 @@ nav:
       - image_policy_delete.py: scripts/image_policy_delete.md
       - image_policy_info.py: scripts/image_policy_info.md
       - image_policy_info_all.py: scripts/image_policy_info_all.md
+      - image_policy_override.py: scripts/image_policy_override.md
       - image_policy_replace.py: scripts/image_policy_replace.md
       - maintenance_mode.py: scripts/maintenance_mode.md
       - maintenance_mode_info.py: scripts/maintenance_mode_info.md


### PR DESCRIPTION
1. lib/ndfc_python/image_policy.py

- Move all image_policy classes into this shared library

2. Refactor the following files to use shared libraries above

- examples/image_policy_create.py
- examples/image_policy_delete.py
- examples/image_policy_info.py
- examples/image_policy_replace.py

3. examples/image_policy_override.py

- Add example script to demonstrate overridden state
- Add documentation for this script, and add it to the nav section of mkdocs.yml
