### PR TITLE
develop: Fix docs rendering issue with wildcard file glob

### DIFF
--- a/docs/scripts/bootflash_files_delete.md
+++ b/docs/scripts/bootflash_files_delete.md
@@ -16,7 +16,7 @@ Can be any file glob (obviously, some are dangerous!).
 
 ##### filepath examples
 
-###### *:/*.txt
+###### \*:/*.txt
 
 Delete all `.txt` files from all flash devices on the specified supervisor
 

--- a/docs/scripts/bootflash_files_info.md
+++ b/docs/scripts/bootflash_files_info.md
@@ -16,7 +16,7 @@ Can be any file glob (obviously, some are dangerous!).
 
 ##### filepath examples
 
-###### *:/*.txt
+###### \*:/*.txt
 
 List all `.txt` files from all flash devices on the specified supervisor
 


### PR DESCRIPTION
Escape the leading '\*' in '\*:/*.txt' so that Mkdocs renders it correctly.

- docs/scripts/bootflash_files_delete.md
- docs/scripts/bootflash_files_info.md