### PR TITLE
develop: Add example script vrf_delete.py and supporting code

### DIFF
--- a/docs/scripts/vrf_delete.md
+++ b/docs/scripts/vrf_delete.md
@@ -1,0 +1,65 @@
+# vrf_delete.py
+
+## Description
+
+Delete one or more VRFs (virtual routing and forwarding instances).
+
+## Example configuration file
+
+``` yaml title="config/config_vrf_create.yaml"
+---
+config:
+  - fabric_name: MyFabric1
+    vrf_names:
+    - MyVrf1
+    - MyVrf2
+  - fabric_name: MyFabric2
+    vrf_names:
+    - MyVrf3
+    - MyVrf4
+```
+
+## Example Usage
+
+The example below uses environment variables for credentials, so requires
+only the `--config` argument.  See [Running the Example Scripts]
+for details around specifying credentials from the command line, from
+environment variables, from Ansible Vault, or a combination of these
+credentials sources.
+
+[Running the Example Scripts]: ../setup/running-the-example-scripts.md
+
+``` bash
+export ND_DOMAIN=local
+export ND_IP4=10.1.1.1
+export ND_PASSWORD=MySecret
+export ND_USERNAME=admin
+./vrf_delete.py --config config/config_vrf_delete.yaml
+# output not shown
+```
+
+## Example output
+
+### Success
+
+``` bash title="VRFs deleted successfully"
+(.venv) AROBEL-M-G793% ./vrf_delete.py --config prod/config_vrf_delete.yaml
+Deleted vrfs MyVrf1,MyVrf2 from fabric f1
+(.venv) AROBEL-M-G793%(.venv) AROBEL-M-G793%
+```
+
+### Failure - VRFs do not exist in fabric f1
+
+``` bash title="VRFs do not exist in the target fabric"
+(.venv) AROBEL-M-G793% ./vrf_delete.py --config prod/config_vrf_create.yaml
+Error deleting vrfs ['MyVrf1', 'MyVrf2'] from fabric f1. Error detail: VrfDelete._final_verification: VRF MyVrf1 does not exist in fabric f1
+(.venv) AROBEL-M-G793%
+```
+
+### Failure - Fabric f2 does not exist
+
+``` bash title="Fabric does not exist"
+(.venv) AROBEL-M-G793% ./vrf_delete.py --config prod/config_vrf_create.yaml
+Error deleting vrfs ['MyVrf1', 'MyVrf2'] from fabric f2. Error detail: VrfDelete.get_vrfs: Fabric f2 does not exist on the controller.
+(.venv) AROBEL-M-G793%
+```

--- a/examples/config/config_vrf_delete.yaml
+++ b/examples/config/config_vrf_delete.yaml
@@ -1,0 +1,10 @@
+---
+config:
+  - fabric_name: MyFabric1
+    vrf_names:
+    - MyVrf1
+    - MyVrf2
+  - fabric_name: MyFabric2
+    vrf_names:
+    - MyVrf3
+    - MyVrf4

--- a/examples/vrf_create.py
+++ b/examples/vrf_create.py
@@ -10,7 +10,7 @@ Add a vrf to a fabric
 
 #Usage
 
-Edit ``examples/config_vrf_create.yaml`` appropriately for your setup.
+Edit ``examples/config/config_vrf_create.yaml`` appropriately for your setup.
 
 ```yaml
 config:
@@ -26,14 +26,14 @@ environment variables (ND_DOMAIN, ND_IP4, ND_PASSWORD, ND_USERNAME)
 then you're good to go.
 
 ```bash
-./vrf_create.py --config config_vrf_create.yaml
+./vrf_create.py --config config/config_vrf_create.yaml
 ```
 
 If you haven't set the standard ndfc-python Nexus Dashboard credentials
 environment variables, you can override them like so:
 
 ```bash
-./vrf_create.py --config device_info_config.yaml --nd-username admin --nd-password MyPassword --nd-domain local --nd-ip4 10.1.1.2
+./vrf_create.py --config config/config_vrf_create.yaml --nd-username admin --nd-password MyPassword --nd-domain local --nd-ip4 10.1.1.2
 """
 # pylint: disable=duplicate-code
 import argparse

--- a/examples/vrf_delete.py
+++ b/examples/vrf_delete.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""
+# Name
+
+vrf_delete.py
+
+# Description
+
+Delete one or more VRFs from a fabric
+
+# Usage
+
+Edit ``examples/config/config_vrf_delete.yaml`` appropriately for your setup.
+
+```yaml
+---
+config:
+  - fabric_name: MyFabric_1
+    vrf_names:
+    - MyVrf1
+    - MyVrf2
+  - fabric_name: MyFabric_2
+    vrf_names:
+    - MyVrf3
+    - MyVrf4
+```
+
+If you've set the standard ndfc-python Nexus Dashboard credentials
+environment variables (ND_DOMAIN, ND_IP4, ND_PASSWORD, ND_USERNAME)
+then you're good to go.
+
+```bash
+./vrf_delete.py --config config_vrf_create.yaml
+```
+
+If you haven't set the standard ndfc-python Nexus Dashboard credentials
+environment variables, you can override them like so:
+
+```bash
+./vrf_delete.py --config config/config_vrf_create.yaml --nd-username admin --nd-password MyPassword --nd-domain local --nd-ip4 10.1.1.2
+"""
+# pylint: disable=duplicate-code
+import argparse
+import json
+import logging
+import sys
+
+from ndfc_python.ndfc_python_logger import NdfcPythonLogger
+from ndfc_python.ndfc_python_sender import NdfcPythonSender
+from ndfc_python.parsers.parser_ansible_vault import parser_ansible_vault
+from ndfc_python.parsers.parser_config import parser_config
+from ndfc_python.parsers.parser_loglevel import parser_loglevel
+from ndfc_python.parsers.parser_nd_domain import parser_nd_domain
+from ndfc_python.parsers.parser_nd_ip4 import parser_nd_ip4
+from ndfc_python.parsers.parser_nd_password import parser_nd_password
+from ndfc_python.parsers.parser_nd_username import parser_nd_username
+from ndfc_python.read_config import ReadConfig
+from ndfc_python.validators.vrf_delete import VrfDeleteConfigValidator
+from ndfc_python.vrf_delete import VrfDelete
+from plugins.module_utils.common.response_handler import ResponseHandler
+from plugins.module_utils.common.rest_send_v2 import RestSend
+from plugins.module_utils.common.results import Results
+from pydantic import ValidationError
+
+
+def vrf_delete(config):
+    """
+    Given a VRF configuration, delete the VRF.
+    """
+    try:
+        instance = VrfDelete()
+        instance.rest_send = rest_send
+        instance.results = Results()
+        instance.fabric_name = config.get("fabric_name")
+        instance.vrf_names = config.get("vrf_names")
+        instance.commit()
+    except (TypeError, ValueError) as error:
+        errmsg = f"Error deleting vrfs {instance.vrf_names} "
+        errmsg += f"from fabric {instance.fabric_name}. "
+        errmsg += f"Error detail: {error}"
+        log.error(errmsg)
+        print(errmsg)
+        return
+
+    vrf_names = ",".join(sorted(instance.vrf_names))
+    result_msg = f"Deleted vrfs {vrf_names} "
+    result_msg += f"from fabric {instance.fabric_name}"
+    log.info(result_msg)
+    print(result_msg)
+
+
+def setup_parser() -> argparse.Namespace:
+    """
+    ### Summary
+
+    Setup script-specific parser
+
+    Returns:
+        argparse.Namespace
+    """
+    parser = argparse.ArgumentParser(
+        parents=[
+            parser_ansible_vault,
+            parser_config,
+            parser_loglevel,
+            parser_nd_domain,
+            parser_nd_ip4,
+            parser_nd_password,
+            parser_nd_username,
+        ],
+        description="DESCRIPTION: Create a vrf.",
+    )
+    return parser.parse_args()
+
+
+args = setup_parser()
+
+
+NdfcPythonLogger()
+log = logging.getLogger("ndfc_python.main")
+log.setLevel = args.loglevel
+
+try:
+    ndfc_sender = NdfcPythonSender()
+    ndfc_sender.args = args
+    ndfc_sender.commit()
+except ValueError as error:
+    msg = f"Exiting.  Error detail: {error}"
+    log.error(msg)
+    print(msg)
+    sys.exit(1)
+
+try:
+    ndfc_config = ReadConfig()
+    ndfc_config.filename = args.config
+    ndfc_config.commit()
+except ValueError as error:
+    msg = f"Exiting: Error detail: {error}"
+    log.error(msg)
+    print(msg)
+    sys.exit()
+
+try:
+    validator = VrfDeleteConfigValidator(**ndfc_config.contents)
+except ValidationError as error:
+    msg = f"{error}"
+    log.error(msg)
+    print(msg)
+    sys.exit(1)
+
+rest_send = RestSend({})
+rest_send.sender = ndfc_sender.sender
+rest_send.response_handler = ResponseHandler()
+rest_send.timeout = 2
+rest_send.send_interval = 5
+
+params_list = json.loads(validator.model_dump_json()).get("config", {})
+
+for params in params_list:
+    vrf_delete(params)

--- a/lib/ndfc_python/validators/vrf_delete.py
+++ b/lib/ndfc_python/validators/vrf_delete.py
@@ -1,0 +1,24 @@
+from typing import List
+
+from pydantic import BaseModel
+
+
+class VrfDeleteConfig(BaseModel):
+    """
+    # Summary
+
+    Base validator for VrfDelete arguments
+    """
+
+    fabric_name: str
+    vrf_names: List[str]
+
+
+class VrfDeleteConfigValidator(BaseModel):
+    """
+    # Summary
+
+    config is a list of VrfDeleteConfig
+    """
+
+    config: List[VrfDeleteConfig]

--- a/lib/ndfc_python/vrf_create.py
+++ b/lib/ndfc_python/vrf_create.py
@@ -1,5 +1,5 @@
 """
-Name: ndfc_vrf.py
+Name: vrf_create.py
 Description: Create VRFs
 """
 
@@ -241,14 +241,10 @@ class VrfCreate:
             msg += f"Error details: {error}"
             raise ValueError(msg) from error
 
-        for item_d in self.rest_send.response_current["DATA"]:
-            if "fabric" not in item_d:
+        for item in self.rest_send.response_current["DATA"]:
+            if item.get("fabric") != self.fabric_name:
                 continue
-            if "vrfId" not in item_d:
-                continue
-            if item_d["fabric"] != self.fabric_name:
-                continue
-            if item_d["vrfId"] != self.vrf_id:
+            if item.get("vrfId") != self.vrf_id:
                 continue
             return True
         # pylint: enable=no-member

--- a/lib/ndfc_python/vrf_delete.py
+++ b/lib/ndfc_python/vrf_delete.py
@@ -1,0 +1,245 @@
+"""
+Name: vrf_delete.py
+Description: Delete VRFs
+"""
+
+# We use isort for import linting
+# pylint: disable=wrong-import-order
+import copy
+import inspect
+import logging
+
+from ndfc_python.validations import Validations
+from plugins.module_utils.common.properties import Properties
+
+
+@Properties.add_rest_send
+@Properties.add_results
+class VrfDelete:
+    """
+    # Summary
+
+    Delete VRFs
+
+    ## Usage
+
+    See examples/vrf_delete.py
+    """
+
+    def __init__(self):
+        self.class_name = __class__.__name__
+        self.log = logging.getLogger(f"ndfc_python.{self.class_name}")
+
+        self.validations = Validations()
+
+        self._rest_send = None
+        self._results = None
+        # _vrf_cache is keyed on fabric_name
+        # The value is a dictionary, keyed on vrf_name.
+        # _vrf_cache = {
+        #     "fabric_1": {
+        #        "vrf_1": {
+        #            "fabric": "fabric_1",
+        #            "vrfName": "vrf_1",
+        #            "vrfTemplate": "Default_VRF_Universal",
+        #            "vrfExtensionTemplate": "Default_VRF_Extension_Universal",
+        #            "vrfTemplateConfig": "stringified template config key/value pairs"
+        #            "id": 12,
+        #            "vrfId": 50002,
+        #            "tenantName": "",
+        #            "vrfServiceTemplate": null,
+        #            "source": null,
+        #            "vrfStatus": "NA",
+        #            "hierarchicalKey": "fabric_1"
+        #            etc...
+        #        },
+        #        "vrf_2": {vrf info for vrf_2}
+        #     },
+        #    "fabric_2": {
+        #        "vrf_3": {vrf info for vrf_3},
+        #        "vrf_4": {vrf info for vrf_4}
+        #    }
+        # }
+        self._vrf_cache = {}
+
+        self._fabric_name = None
+        self._vrf_names = None
+
+    def _final_verification(self) -> None:
+        """
+        # Summary
+
+        Verify the following:
+
+        - verify rest_send is set
+        - verify results is set
+        - Each vrf in self.vrf_names exists in self.fabric_name
+
+        # Raises
+
+        - `ValueError` if above verifications fail.
+        """
+        method_name = inspect.stack()[0][3]
+        # pylint: disable=no-member
+        if self.rest_send is None:  # type: ignore[attr-defined]
+            msg = f"{self.class_name}.{method_name}: "
+            msg += f"{self.class_name}.rest_send must be set before calling "
+            msg += f"{self.class_name}.commit"
+            raise ValueError(msg)
+        if self.results is None:  # type: ignore[attr-defined]
+            msg = f"{self.class_name}.{method_name}: "
+            msg += f"{self.class_name}.results must be set before calling "
+            msg += f"{self.class_name}.commit"
+            raise ValueError(msg)
+        # pylint: enable=no-member
+
+        if self.fabric_name is None:
+            msg = f"{self.class_name}.{method_name}: "
+            msg += f"{self.class_name}.fabric_name must be set before calling "
+            msg += f"{self.class_name}.commit"
+            raise ValueError(msg)
+
+        if self.vrf_names is None:
+            msg = f"{self.class_name}.{method_name}: "
+            msg += f"{self.class_name}.vrf_names must be set before calling "
+            msg += f"{self.class_name}.commit"
+            raise ValueError(msg)
+
+        self.get_vrfs()
+
+        for vrf_name in self.vrf_names:
+            if self.vrf_exists_in_fabric(vrf_name) is False:
+                msg = f"{self.class_name}.{method_name}: "
+                msg += f"VRF {vrf_name} does not exist in "
+                msg += f"fabric {self.fabric_name}"
+                raise ValueError(msg)
+
+    def commit(self) -> None:
+        """
+        # Summary
+
+        Commit VRF deletion
+
+        ## Raises
+
+        - ValueError if an error is encountered while sending the request.
+        """
+        method_name = inspect.stack()[0][3]
+        self._final_verification()
+
+        vrf_names = ",".join(self.vrf_names)
+        # TODO: update when this path is added to ansible-dcnm
+        path = "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/top-down/fabrics"
+        path += f"/{self.fabric_name}/bulk-delete/vrfs?vrf-names={vrf_names}"
+
+        # pylint: disable=no-member
+        try:
+            self.rest_send.path = path  # type: ignore[attr-defined]
+            self.rest_send.verb = "DELETE"  # type: ignore[attr-defined]
+            self.rest_send.commit()  # type: ignore[attr-defined]
+        except (TypeError, ValueError) as error:
+            msg = f"{self.class_name}.{method_name}: "
+            msg += f"Unable to send {self.rest_send.verb} request to the controller. "  # type: ignore[attr-defined]
+            msg += f"Error details: {error}"
+            raise ValueError(msg) from error
+
+        if self.rest_send.result_current.get("success") is False:  # type: ignore[attr-defined]
+            msg = f"{self.class_name}.{method_name}: "
+            msg += "RestSend returned an unsuccessful result "
+            msg += f"{self.rest_send.result_current}. "  # type: ignore[attr-defined]
+            msg += "More detail (if any): "
+            msg += f"{self.rest_send.response_current.get('DATA', {}).get('message')}"  # type: ignore[attr-defined]
+            raise ValueError(msg)
+        # pylint: enable=no-member
+
+    def get_vrfs(self) -> None:
+        """
+        # Summary
+
+        Get information for all vrfs in self.fabric_name and cache the results.
+
+        For each vrf in self.fabric_name, set:
+
+        self._vrf_cache[self.fabric_name][vrf_name] = {vrf_info dict}
+
+        ## Raises
+
+        -   `ValueError` if errors are encountered retrieving VRF information
+            from the controller.
+        """
+        if self._vrf_cache.get(self.fabric_name) is not None:
+            return
+        method_name = inspect.stack()[0][3]
+        # TODO: update when this path is added to ansible-dcnm
+        path = "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/top-down/fabrics"
+        path += f"/{self.fabric_name}/vrfs"
+        verb = "GET"
+
+        # pylint: disable=no-member
+        try:
+            self.rest_send.path = path  # type: ignore[attr-defined]
+            self.rest_send.verb = verb  # type: ignore[attr-defined]
+            self.rest_send.commit()  # type: ignore[attr-defined]
+            data = self.rest_send.response_current["DATA"]  # type: ignore[attr-defined]
+            if not isinstance(data, list):
+                if data.get("message") == "Resource not found":
+                    error = f"Fabric {self.fabric_name} does not exist "
+                    error += "on the controller."
+                else:
+                    error = data.get("message")
+                raise ValueError(error)
+
+            if self.fabric_name not in self._vrf_cache:
+                self._vrf_cache[self.fabric_name] = {}
+
+            for item in data:
+                vrf_name = item.get("vrfName")
+                if vrf_name is None:
+                    continue
+                self._vrf_cache[self.fabric_name][vrf_name] = copy.deepcopy(item)
+        except (TypeError, ValueError) as error:
+            msg = f"{self.class_name}.{method_name}: "
+            msg += f"{error}"
+            raise ValueError(msg) from error
+
+    def vrf_exists_in_fabric(self, vrf_name: str) -> bool:
+        """
+        # Summary
+
+        Return True if `vrf_name` exists in fabric `self.fabric_name`.
+
+        Return False otherwise.
+        """
+        if self.fabric_name not in self._vrf_cache:
+            return False
+        if vrf_name not in self._vrf_cache[self.fabric_name]:
+            return False
+        return True
+
+    @property
+    def fabric_name(self) -> str:
+        """
+        # Summary
+
+        The fabric_name set by the user
+        """
+        return self._fabric_name
+
+    @fabric_name.setter
+    def fabric_name(self, value: str):
+        self._fabric_name = value
+
+    @property
+    def vrf_names(self) -> str:
+        """
+        The list of vrf names set by the user
+        """
+        return self._vrf_names
+
+    @vrf_names.setter
+    def vrf_names(self, value: str) -> None:
+        if not isinstance(value, list):
+            msg = "vrf_names must be a list of vrf names. "
+            msg += f"Got: {value}"
+            raise ValueError(msg)
+        self._vrf_names = value

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -94,6 +94,7 @@ nav:
       - rest_get_request.py: scripts/rest_get_request.md
       - rest_post_request.py: scripts/rest_post_request.md
       - vrf_create.py: scripts/vrf_create.md
+      - vrf_delete.py: scripts/vrf_delete.md
   - Classes:
       - Overview: classes/overview.md
       - CredentialSelector: classes/CredentialSelector.md


### PR DESCRIPTION
1. mkdocs.py

- Add link to vrf_delete.md to the nav section

2. lib/ndfc_python/vrf_delete.py

- New class VrfDelete() supporting vrf deletion

3. lib/ndfc_python/validators/vrf_delete.py

- Validation for examples/config/config_vrf_delete.yaml

4. examples/vrf_delete.py

- Example script leveraging VrfDelete()

5. examples/config/config_vrf_delete.yaml

- Example config file for examples/vrf_delete.py

6. docs/scripts/vrf_delete.md

- Documentation for examples/vrf_delete.py

7. lib/ndfc_python/vrf_create.py

- Fix script name in docstring.

- Rename var item_d to item.

8. examples/vrf_create.py

- Fix docstrings


