### PR TITLE
develop: Add examples for fabric_create and fabric_replace

### DIFF
--- a/docs/scripts/fabric_create.md
+++ b/docs/scripts/fabric_create.md
@@ -1,0 +1,256 @@
+# fabric_create.py
+
+## Description
+
+Create or update one or more fabrics.
+
+## Example configuration file
+
+Note, for a description of all configuration parameters for all fabric types
+see [dcnm_fabric](https://allenrobel.github.io/dcnm-docpoc/modules/dcnm_fabric/).
+
+``` yaml title="config/config_fabric_create.yaml"
+---
+config:
+  - FABRIC_NAME: MyFabric
+    FABRIC_TYPE: VXLAN_EVPN
+    BGP_AS: 65002
+    REPLICATION_MODE: Ingress
+    VRF_VLAN_RANGE: 2000-2299
+  - FABRIC_NAME: YourFabric
+    FABRIC_TYPE: LAN_Classic
+    BGP_AS: 65003
+```
+
+## Example Usage
+
+The example below uses environment variables for credentials, so requires
+only the `--config` argument.  See [Running the Example Scripts]
+for details around specifying credentials from the command line, from
+environment variables, from Ansible Vault, or a combination of these
+credentials sources.
+
+[Running the Example Scripts]: ../setup/running-the-example-scripts.md
+
+``` bash
+export ND_DOMAIN=local
+export ND_IP4=10.1.1.1
+export ND_PASSWORD=MySecret
+export ND_USERNAME=admin
+./fabric_create.py --config config/config_fabric_create.yaml
+# output not shown
+```
+
+## Example output
+
+### Fabrics created successfully
+
+``` bash title="Fabrics create success"
+(.venv) AROBEL-M-G793% ./fabric_create.py --config prod/config_fabric_create.yaml
+{
+    "changed": true,
+    "diff": [
+        {
+            "BGP_AS": 65002,
+            "FABRIC_NAME": "MyFabric",
+            "REPLICATION_MODE": "Ingress",
+            "VRF_VLAN_RANGE": "2000-2299",
+            "sequence_number": 1
+        },
+        {
+            "FABRIC_NAME": "YourFabric",
+            "sequence_number": 2
+        }
+    ],
+    "failed": false,
+    "metadata": [
+        {
+            "action": "fabric_create",
+            "check_mode": false,
+            "sequence_number": 1,
+            "state": "merged"
+        },
+        {
+            "action": "fabric_create",
+            "check_mode": false,
+            "sequence_number": 2,
+            "state": "merged"
+        }
+    ],
+    "response": [
+        {
+            "DATA": {
+                "removed": "for brevity"
+            },
+            "MESSAGE": "OK",
+            "METHOD": "POST",
+            "REQUEST_PATH": "https://10.1.1.1/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/MyFabric/Easy_Fabric",
+            "RETURN_CODE": 200,
+            "sequence_number": 1
+        },
+        {
+            "DATA": {
+                "removed": "for brevity"
+            },
+            "MESSAGE": "OK",
+            "METHOD": "POST",
+            "REQUEST_PATH": "https://10.1.1.1/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/YourFabric/LAN_Classic",
+            "RETURN_CODE": 200,
+            "sequence_number": 2
+        }
+    ],
+    "result": [
+        {
+            "changed": true,
+            "sequence_number": 1,
+            "success": true
+        },
+        {
+            "changed": true,
+            "sequence_number": 2,
+            "success": true
+        }
+    ]
+}
+(.venv) AROBEL-M-G793%
+```
+
+### Fabrics already exist, and no changes are required
+
+``` bash title="Fabrics do not require changes"
+(.venv) AROBEL-M-G793% ./fabric_create.py --ansible-vault $HOME/.ansible/vault --config prod/config_fabric_create.yaml
+Vault password:
+{
+    "changed": false,
+    "diff": [
+        {
+            "sequence_number": 1
+        }
+    ],
+    "failed": false,
+    "metadata": [
+        {
+            "action": "fabric_update",
+            "check_mode": false,
+            "sequence_number": 1,
+            "state": "merged"
+        }
+    ],
+    "response": [
+        {
+            "MESSAGE": "No fabrics to update for merged state.",
+            "RETURN_CODE": 200,
+            "sequence_number": 1
+        }
+    ],
+    "result": [
+        {
+            "changed": false,
+            "sequence_number": 1,
+            "success": true
+        }
+    ]
+}
+(.venv) AROBEL-M-G793%
+```
+
+### Fabric already exists, but requires changes to align with user's config
+
+Below, we have changed ``REPLICATION_MODE`` and `BGP_AS` for fabric `MyFabric`
+Since `SITE_ID`, by default, is assigned the value of `BGP_AS`, we need to change
+it as well if we want it to be in sync with `BGP_AS`
+
+``` yaml title="config/config_fabric_create.yaml"
+---
+config:
+  - FABRIC_NAME: MyFabric
+    FABRIC_TYPE: VXLAN_EVPN
+    BGP_AS: 65004
+    SITE_ID: 65004
+    REPLICATION_MODE: Multicast
+    VRF_VLAN_RANGE: 2000-2299
+  - FABRIC_NAME: YourFabric
+    FABRIC_TYPE: LAN_Classic
+    BGP_AS: 65003
+```
+
+``` bash title="User config changed some MyFabric parameters"
+{
+    "changed": true,
+    "diff": [
+        {
+            "BGP_AS": "65004",
+            "FABRIC_NAME": "MyFabric",
+            "REPLICATION_MODE": "Multicast",
+            "SITE_ID": "65004",
+            "sequence_number": 1
+        },
+        {
+            "sequence_number": 2
+        },
+        {
+            "sequence_number": 3
+        }
+    ],
+    "failed": false,
+    "metadata": [
+        {
+            "action": "fabric_update",
+            "check_mode": false,
+            "sequence_number": 1,
+            "state": "merged"
+        },
+        {
+            "action": "config_save",
+            "check_mode": false,
+            "sequence_number": 2,
+            "state": "merged"
+        },
+        {
+            "action": "config_deploy",
+            "check_mode": false,
+            "sequence_number": 3,
+            "state": "merged"
+        }
+    ],
+    "response": [
+        {
+            "DATA": {
+                "removed": "for_brevity"
+            },
+            "MESSAGE": "OK",
+            "METHOD": "PUT",
+            "REQUEST_PATH": "https://10.1.1.1/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/MyFabric/Easy_Fabric",
+            "RETURN_CODE": 200,
+            "sequence_number": 1
+        },
+        {
+            "MESSAGE": "Fabric MyFabric DEPLOY is False or None. Skipping config-save.",
+            "RETURN_CODE": 200,
+            "sequence_number": 2
+        },
+        {
+            "MESSAGE": "FabricConfigDeploy._can_fabric_be_deployed: Fabric MyFabric DEPLOY is False or None. Skipping config-deploy.",
+            "RETURN_CODE": 200,
+            "sequence_number": 3
+        }
+    ],
+    "result": [
+        {
+            "changed": true,
+            "sequence_number": 1,
+            "success": true
+        },
+        {
+            "changed": true,
+            "sequence_number": 2,
+            "success": true
+        },
+        {
+            "changed": true,
+            "sequence_number": 3,
+            "success": true
+        }
+    ]
+}
+```

--- a/docs/scripts/fabric_replace.md
+++ b/docs/scripts/fabric_replace.md
@@ -1,0 +1,401 @@
+# fabric_replace.py
+
+## Description
+
+Replace the configuration for one or more fabrics.
+
+## Example configuration file
+
+Note, for a description of all configuration parameters for all fabric types
+see [dcnm_fabric](https://allenrobel.github.io/dcnm-docpoc/modules/dcnm_fabric/).
+
+``` yaml title="config/config_fabric_replace.yaml"
+---
+config:
+  - FABRIC_NAME: MyFabric
+    FABRIC_TYPE: VXLAN_EVPN
+    REPLICATION_MODE: Ingress
+  - FABRIC_NAME: YourFabric
+    FABRIC_TYPE: LAN_Classic
+    IS_READ_ONLY: False
+```
+
+## Example Usage
+
+The example below uses environment variables for credentials, so requires
+only the `--config` argument.  See [Running the Example Scripts]
+for details around specifying credentials from the command line, from
+environment variables, from Ansible Vault, or a combination of these
+credentials sources.
+
+[Running the Example Scripts]: ../setup/running-the-example-scripts.md
+
+``` bash
+export ND_DOMAIN=local
+export ND_IP4=10.1.1.1
+export ND_PASSWORD=MySecret
+export ND_USERNAME=admin
+./fabric_replace.py --config config/config_fabric_replace.yaml
+# output not shown
+```
+
+## Example output
+
+### Fabric configurations replaced successfully
+
+``` yaml title="config/config_fabric_replace.yaml"
+---
+config:
+  - FABRIC_NAME: MyFabric
+    FABRIC_TYPE: VXLAN_EVPN
+    REPLICATION_MODE: Multicast
+  - FABRIC_NAME: YourFabric
+    FABRIC_TYPE: LAN_Classic
+    IS_READ_ONLY: False
+```
+
+``` bash title="Fabric configuration replace success"
+(.venv) AROBEL-M-G793% ./fabric_replace.py --ansible-vault $HOME/.ansible/vault --config prod/config_fabric_create.yaml
+Vault password:
+{
+    "changed": true,
+    "diff": [
+        {
+            "FABRIC_NAME": "MyFabric",
+            "REPLICATION_MODE": "Multicast",
+            "sequence_number": 1
+        },
+        {
+            "FABRIC_NAME": "YourFabric",
+            "IS_READ_ONLY": "false",
+            "sequence_number": 2
+        },
+        {
+            "sequence_number": 3
+        },
+        {
+            "sequence_number": 4
+        },
+        {
+            "sequence_number": 5
+        },
+        {
+            "sequence_number": 6
+        }
+    ],
+    "failed": false,
+    "metadata": [
+        {
+            "action": "fabric_replace",
+            "check_mode": false,
+            "sequence_number": 1,
+            "state": "replaced"
+        },
+        {
+            "action": "fabric_replace",
+            "check_mode": false,
+            "sequence_number": 2,
+            "state": "replaced"
+        },
+        {
+            "action": "config_save",
+            "check_mode": false,
+            "sequence_number": 3,
+            "state": "replaced"
+        },
+        {
+            "action": "config_save",
+            "check_mode": false,
+            "sequence_number": 4,
+            "state": "replaced"
+        },
+        {
+            "action": "config_deploy",
+            "check_mode": false,
+            "sequence_number": 5,
+            "state": "replaced"
+        },
+        {
+            "action": "config_deploy",
+            "check_mode": false,
+            "sequence_number": 6,
+            "state": "replaced"
+        }
+    ],
+    "response": [
+        {
+            "DATA": {
+                "removed": "for brevity"
+            },
+            "MESSAGE": "OK",
+            "METHOD": "PUT",
+            "REQUEST_PATH": "https://10.1.1.1/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/MyFabric/Easy_Fabric",
+            "RETURN_CODE": 200,
+            "sequence_number": 1
+        },
+        {
+            "DATA": {
+                "removed": "for brevity"
+            },
+            "MESSAGE": "OK",
+            "METHOD": "PUT",
+            "REQUEST_PATH": "https://10.1.1.1/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/YourFabric/LAN_Classic",
+            "RETURN_CODE": 200,
+            "sequence_number": 2
+        },
+        {
+            "MESSAGE": "Fabric MyFabric DEPLOY is False or None. Skipping config-save.",
+            "RETURN_CODE": 200,
+            "sequence_number": 3
+        },
+        {
+            "MESSAGE": "Fabric YourFabric DEPLOY is False or None. Skipping config-save.",
+            "RETURN_CODE": 200,
+            "sequence_number": 4
+        },
+        {
+            "MESSAGE": "FabricConfigDeploy._can_fabric_be_deployed: Fabric MyFabric DEPLOY is False or None. Skipping config-deploy.",
+            "RETURN_CODE": 200,
+            "sequence_number": 5
+        },
+        {
+            "MESSAGE": "FabricConfigDeploy._can_fabric_be_deployed: Fabric YourFabric DEPLOY is False or None. Skipping config-deploy.",
+            "RETURN_CODE": 200,
+            "sequence_number": 6
+        }
+    ],
+    "result": [
+        {
+            "changed": true,
+            "sequence_number": 1,
+            "success": true
+        },
+        {
+            "changed": true,
+            "sequence_number": 2,
+            "success": true
+        },
+        {
+            "changed": true,
+            "sequence_number": 3,
+            "success": true
+        },
+        {
+            "changed": true,
+            "sequence_number": 4,
+            "success": true
+        },
+        {
+            "changed": true,
+            "sequence_number": 5,
+            "success": true
+        },
+        {
+            "changed": true,
+            "sequence_number": 6,
+            "success": true
+        }
+    ]
+}
+```
+
+### No changes are required
+
+``` bash title="Fabrics do not require changes"
+(.venv) AROBEL-M-G793% ./fabric_replace.py --ansible-vault $HOME/.ansible/vault --config prod/config_fabric_replace.yaml
+{
+    "changed": false,
+    "diff": [
+        {
+            "sequence_number": 1
+        }
+    ],
+    "failed": false,
+    "metadata": [
+        {
+            "action": "fabric_replace",
+            "check_mode": false,
+            "sequence_number": 1,
+            "state": "replaced"
+        }
+    ],
+    "response": [
+        {
+            "MESSAGE": "No fabrics to update for replaced state.",
+            "RETURN_CODE": 200,
+            "sequence_number": 1
+        }
+    ],
+    "result": [
+        {
+            "changed": false,
+            "sequence_number": 1,
+            "success": true
+        }
+    ]
+}
+(.venv) AROBEL-M-G793%
+```
+
+### Fabric requires changes to align with user's config
+
+Below, we have changed ``REPLICATION_MODE`` for `MyFabric` and
+`IS_READ_ONLY` for `YourFabric`
+
+``` yaml title="config/config_fabric_replace.yaml"
+---
+config:
+  - FABRIC_NAME: MyFabric
+    REPLICATION_MODE: Multicast
+    FABRIC_TYPE: VXLAN_EVPN
+    BGP_AS: 65004
+    DEPLOY: False
+  - FABRIC_NAME: YourFabric
+    FABRIC_TYPE: LAN_CLASSIC
+    IS_READ_ONLY: True
+    DEPLOY: False
+```
+
+``` bash title="User config changed some MyFabric parameters"
+{
+    "changed": true,
+    "diff": [
+        {
+            "FABRIC_NAME": "MyFabric",
+            "REPLICATION_MODE": "Multicast",
+            "sequence_number": 1
+        },
+        {
+            "FABRIC_NAME": "YourFabric",
+            "IS_READ_ONLY": "true",
+            "sequence_number": 2
+        },
+        {
+            "sequence_number": 3
+        },
+        {
+            "sequence_number": 4
+        },
+        {
+            "sequence_number": 5
+        },
+        {
+            "sequence_number": 6
+        }
+    ],
+    "failed": false,
+    "metadata": [
+        {
+            "action": "fabric_replace",
+            "check_mode": false,
+            "sequence_number": 1,
+            "state": "replaced"
+        },
+        {
+            "action": "fabric_replace",
+            "check_mode": false,
+            "sequence_number": 2,
+            "state": "replaced"
+        },
+        {
+            "action": "config_save",
+            "check_mode": false,
+            "sequence_number": 3,
+            "state": "replaced"
+        },
+        {
+            "action": "config_save",
+            "check_mode": false,
+            "sequence_number": 4,
+            "state": "replaced"
+        },
+        {
+            "action": "config_deploy",
+            "check_mode": false,
+            "sequence_number": 5,
+            "state": "replaced"
+        },
+        {
+            "action": "config_deploy",
+            "check_mode": false,
+            "sequence_number": 6,
+            "state": "replaced"
+        }
+    ],
+    "response": [
+        {
+            "DATA": {
+                "removed": "for brevity"
+            },
+            "MESSAGE": "OK",
+            "METHOD": "PUT",
+            "REQUEST_PATH": "https://10.1.1.1/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/MyFabric/Easy_Fabric",
+            "RETURN_CODE": 200,
+            "sequence_number": 1
+        },
+        {
+            "DATA": {
+                "removed": "for brevity"
+            },
+            "MESSAGE": "OK",
+            "METHOD": "PUT",
+            "REQUEST_PATH": "https://10.1.1.1/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/YourFabric/LAN_Classic",
+            "RETURN_CODE": 200,
+            "sequence_number": 2
+        },
+        {
+            "MESSAGE": "Fabric MyFabric DEPLOY is False or None. Skipping config-save.",
+            "RETURN_CODE": 200,
+            "sequence_number": 3
+        },
+        {
+            "MESSAGE": "Fabric YourFabric DEPLOY is False or None. Skipping config-save.",
+            "RETURN_CODE": 200,
+            "sequence_number": 4
+        },
+        {
+            "MESSAGE": "FabricConfigDeploy._can_fabric_be_deployed: Fabric MyFabric DEPLOY is False or None. Skipping config-deploy.",
+            "RETURN_CODE": 200,
+            "sequence_number": 5
+        },
+        {
+            "MESSAGE": "FabricConfigDeploy._can_fabric_be_deployed: Fabric YourFabric DEPLOY is False or None. Skipping config-deploy.",
+            "RETURN_CODE": 200,
+            "sequence_number": 6
+        }
+    ],
+    "result": [
+        {
+            "changed": true,
+            "sequence_number": 1,
+            "success": true
+        },
+        {
+            "changed": true,
+            "sequence_number": 2,
+            "success": true
+        },
+        {
+            "changed": true,
+            "sequence_number": 3,
+            "success": true
+        },
+        {
+            "changed": true,
+            "sequence_number": 4,
+            "success": true
+        },
+        {
+            "changed": true,
+            "sequence_number": 5,
+            "success": true
+        },
+        {
+            "changed": true,
+            "sequence_number": 6,
+            "success": true
+        }
+    ]
+}
+(.venv) AROBEL-M-G793%
+```

--- a/docs/scripts/image_policy_create.md
+++ b/docs/scripts/image_policy_create.md
@@ -183,7 +183,7 @@ export ND_USERNAME=admin
 
 ### No changes to image policies are required
 
-``` bash title="Image policies no not require changes"
+``` bash title="Image policies do not require changes"
 (.venv) AROBEL-M-G793% ./image_policy_create.py --config prod/config_image_policy_create.yaml
 {
     "changed": false,

--- a/examples/credentials.py
+++ b/examples/credentials.py
@@ -68,7 +68,7 @@ are set, the Ansible vault file is used.
 Vault password:
 The following credentials would be used:
   nd_domain local
-  nd_ip4 172.22.150.244
+  nd_ip4 10.1.1.1
   nd_password FooPassword
   nd_username admin
   nxos_password BarPassword

--- a/examples/fabric_create.py
+++ b/examples/fabric_create.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2024 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# pylint: disable=wrong-import-position
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+__author__ = "Allen Robel"
+
+import argparse
+import json
+import logging
+import sys
+
+from ndfc_python.fabric import Merged
+from ndfc_python.ndfc_python_logger import NdfcPythonLogger
+from ndfc_python.ndfc_python_sender import NdfcPythonSender
+from ndfc_python.parsers.parser_ansible_vault import parser_ansible_vault
+from ndfc_python.parsers.parser_config import parser_config
+from ndfc_python.parsers.parser_loglevel import parser_loglevel
+from ndfc_python.parsers.parser_nd_domain import parser_nd_domain
+from ndfc_python.parsers.parser_nd_ip4 import parser_nd_ip4
+from ndfc_python.parsers.parser_nd_password import parser_nd_password
+from ndfc_python.parsers.parser_nd_username import parser_nd_username
+from ndfc_python.parsers.parser_nxos_password import parser_nxos_password
+from ndfc_python.parsers.parser_nxos_username import parser_nxos_username
+from ndfc_python.read_config import ReadConfig
+from plugins.module_utils.common.response_handler import ResponseHandler
+from plugins.module_utils.common.rest_send_v2 import RestSend
+
+
+def setup_parser() -> argparse.Namespace:
+    """
+    ### Summary
+
+    Setup script-specific parser
+
+    Returns:
+        argparse.Namespace
+    """
+    description = "DESCRIPTION: "
+    description += "Create/update fabrics."
+    parser = argparse.ArgumentParser(
+        parents=[
+            parser_ansible_vault,
+            parser_config,
+            parser_loglevel,
+            parser_nd_domain,
+            parser_nd_ip4,
+            parser_nd_password,
+            parser_nd_username,
+            parser_nxos_password,
+            parser_nxos_username,
+        ],
+        description=description,
+    )
+    return parser.parse_args()
+
+
+def main():
+    """
+    main entry point for module execution
+    """
+    args = setup_parser()
+    NdfcPythonLogger()
+    log = logging.getLogger("ndfc_python.main")
+    log.setLevel = args.loglevel
+
+    try:
+        ndfc_config = ReadConfig()
+        ndfc_config.filename = args.config
+        ndfc_config.commit()
+    except ValueError as error:
+        err_msg = f"Exiting: Error detail: {error}"
+        log.error(err_msg)
+        print(err_msg)
+        sys.exit(1)
+
+    validated_config = ndfc_config.contents
+
+    try:
+        ndfc_sender = NdfcPythonSender()
+        ndfc_sender.args = args
+        ndfc_sender.commit()
+    except ValueError as error:
+        err_msg = f"Exiting.  Error detail: {error}"
+        log.error(err_msg)
+        print(err_msg)
+        sys.exit(1)
+
+    params = {}
+    params["check_mode"] = False
+    params["state"] = "merged"
+    params["config"] = validated_config.get("config")
+
+    rest_send = RestSend(params)
+    rest_send.send_interval = 3
+    rest_send.timeout = 9
+    rest_send.sender = ndfc_sender.sender
+    rest_send.response_handler = ResponseHandler()
+
+    try:
+        task = Merged(params)
+        task.rest_send = rest_send
+        task.commit()
+    except ValueError as error:
+        err_msg = f"Exiting.  Error detail: {error}"
+        log.error(err_msg)
+        print(err_msg)
+        sys.exit(1)
+
+    task.results.build_final_result()
+    # pylint: disable=unsupported-membership-test
+    if True in task.results.failed:
+        err_msg = "unable to create/update fabric(s)"
+        log.error(err_msg)
+        print(err_msg)
+    print(json.dumps(task.results.final_result, indent=4, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/fabric_replace.py
+++ b/examples/fabric_replace.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python
+#
+# Copyright (c) 2024 Cisco and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# pylint: disable=wrong-import-position
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+__author__ = "Allen Robel"
+
+import argparse
+import json
+import logging
+import sys
+
+from ndfc_python.fabric import Replaced
+from ndfc_python.ndfc_python_logger import NdfcPythonLogger
+from ndfc_python.ndfc_python_sender import NdfcPythonSender
+from ndfc_python.parsers.parser_ansible_vault import parser_ansible_vault
+from ndfc_python.parsers.parser_config import parser_config
+from ndfc_python.parsers.parser_loglevel import parser_loglevel
+from ndfc_python.parsers.parser_nd_domain import parser_nd_domain
+from ndfc_python.parsers.parser_nd_ip4 import parser_nd_ip4
+from ndfc_python.parsers.parser_nd_password import parser_nd_password
+from ndfc_python.parsers.parser_nd_username import parser_nd_username
+from ndfc_python.parsers.parser_nxos_password import parser_nxos_password
+from ndfc_python.parsers.parser_nxos_username import parser_nxos_username
+from ndfc_python.read_config import ReadConfig
+from plugins.module_utils.common.response_handler import ResponseHandler
+from plugins.module_utils.common.rest_send_v2 import RestSend
+
+
+def setup_parser() -> argparse.Namespace:
+    """
+    ### Summary
+
+    Setup script-specific parser
+
+    Returns:
+        argparse.Namespace
+    """
+    description = "DESCRIPTION: "
+    description += "Create/update fabrics."
+    parser = argparse.ArgumentParser(
+        parents=[
+            parser_ansible_vault,
+            parser_config,
+            parser_loglevel,
+            parser_nd_domain,
+            parser_nd_ip4,
+            parser_nd_password,
+            parser_nd_username,
+            parser_nxos_password,
+            parser_nxos_username,
+        ],
+        description=description,
+    )
+    return parser.parse_args()
+
+
+def main():
+    """
+    main entry point for module execution
+    """
+    args = setup_parser()
+    NdfcPythonLogger()
+    log = logging.getLogger("ndfc_python.main")
+    log.setLevel = args.loglevel
+
+    try:
+        ndfc_config = ReadConfig()
+        ndfc_config.filename = args.config
+        ndfc_config.commit()
+    except ValueError as error:
+        err_msg = f"Exiting: Error detail: {error}"
+        log.error(err_msg)
+        print(err_msg)
+        sys.exit(1)
+
+    validated_config = ndfc_config.contents
+
+    try:
+        ndfc_sender = NdfcPythonSender()
+        ndfc_sender.args = args
+        ndfc_sender.commit()
+    except ValueError as error:
+        err_msg = f"Exiting.  Error detail: {error}"
+        log.error(err_msg)
+        print(err_msg)
+        sys.exit(1)
+
+    params = {}
+    params["check_mode"] = False
+    params["state"] = "replaced"
+    params["config"] = validated_config.get("config")
+
+    rest_send = RestSend(params)
+    rest_send.send_interval = 3
+    rest_send.timeout = 9
+    rest_send.sender = ndfc_sender.sender
+    rest_send.response_handler = ResponseHandler()
+
+    try:
+        task = Replaced(params)
+        task.rest_send = rest_send
+        task.commit()
+    except ValueError as error:
+        err_msg = f"Exiting.  Error detail: {error}"
+        log.error(err_msg)
+        print(err_msg)
+        sys.exit(1)
+
+    task.results.build_final_result()
+    # pylint: disable=unsupported-membership-test
+    if True in task.results.failed:
+        err_msg = "unable to replace fabric(s)"
+        log.error(err_msg)
+        print(err_msg)
+    print(json.dumps(task.results.final_result, indent=4, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/ndfc_python/fabric.py
+++ b/lib/ndfc_python/fabric.py
@@ -246,6 +246,9 @@ class Deleted(Common):
 
         self.log = logging.getLogger(f"dcnm.{self.class_name}")
 
+        self.fabric_details = FabricDetailsByName()
+        self.fabric_summary = FabricSummary()
+
         msg = "ENTERED Deleted(): "
         msg += f"state: {self.results.state}, "
         msg += f"check_mode: {self.results.check_mode}"
@@ -267,12 +270,10 @@ class Deleted(Common):
         msg = f"ENTERED: {self.class_name}.{method_name}"
         self.log.debug(msg)
 
-        self.fabric_details = FabricDetailsByName()
         # pylint: disable=no-member
         self.fabric_details.rest_send = self.rest_send
         self.fabric_details.results = Results()
 
-        self.fabric_summary = FabricSummary()
         self.fabric_summary.rest_send = self.rest_send
         self.fabric_summary.results = Results()
 
@@ -586,6 +587,7 @@ class Query(Common):
         self._implemented_states.add("query")
 
         self.log = logging.getLogger(f"dcnm.{self.class_name}")
+        self.fabric_details = FabricDetailsByName()
 
         msg = "ENTERED Query(): "
         msg += f"state: {self.state}, "
@@ -604,7 +606,6 @@ class Query(Common):
             -   The controller returns an error when attempting to
                 query the fabrics.
         """
-        self.fabric_details = FabricDetailsByName()
         # pylint: disable=no-member
         self.fabric_details.rest_send = self.rest_send
         self.fabric_details.results = Results()

--- a/lib/ndfc_python/fabric.py
+++ b/lib/ndfc_python/fabric.py
@@ -1,0 +1,794 @@
+import copy
+import inspect
+import json
+import logging
+
+from plugins.module_utils.common.controller_features import ControllerFeatures
+from plugins.module_utils.common.exceptions import ControllerResponseError
+from plugins.module_utils.common.properties import Properties
+from plugins.module_utils.common.results import Results
+from plugins.module_utils.fabric.common import FabricCommon
+from plugins.module_utils.fabric.create import FabricCreateBulk
+from plugins.module_utils.fabric.delete import FabricDelete
+from plugins.module_utils.fabric.fabric_details_v2 import FabricDetailsByName
+from plugins.module_utils.fabric.fabric_summary import FabricSummary
+from plugins.module_utils.fabric.fabric_types import FabricTypes
+from plugins.module_utils.fabric.query import FabricQuery
+from plugins.module_utils.fabric.replaced import FabricReplacedBulk
+from plugins.module_utils.fabric.template_get import TemplateGet
+from plugins.module_utils.fabric.update import FabricUpdateBulk
+from plugins.module_utils.fabric.verify_playbook_params import VerifyPlaybookParams
+
+
+def json_pretty(msg):
+    """
+    Return a pretty-printed JSON string for logging messages
+    """
+    return json.dumps(msg, indent=4, sort_keys=True)
+
+
+@Properties.add_rest_send
+class Common(FabricCommon):
+    """
+    Common methods, properties, and resources for all states.
+    """
+
+    def __init__(self, params):
+        self.class_name = self.__class__.__name__
+        self.log = logging.getLogger(f"dcnm.{self.class_name}")
+        super().__init__()
+        method_name = inspect.stack()[0][3]  # pylint: disable=unused-variable
+
+        self.controller_features = ControllerFeatures()
+        self.features = {}
+        self._implemented_states = set()
+
+        self.params = params
+        # populated in self.validate_input()
+        self.payloads = {}
+
+        self.populate_check_mode()
+        self.populate_state()
+        self.populate_config()
+
+        self.results = Results()
+        self.results.state = self.state
+        self.results.check_mode = self.check_mode
+        self._rest_send = None
+        self._verify_playbook_params = VerifyPlaybookParams()
+
+        self.have = {}
+        self.query = []
+        self.validated = []
+        self.want = []
+
+        msg = f"ENTERED Common().{method_name}: "
+        msg += f"state: {self.state}, "
+        msg += f"check_mode: {self.check_mode}"
+        self.log.debug(msg)
+
+    def populate_check_mode(self):
+        """
+        ### Summary
+        Populate ``check_mode`` with the playbook check_mode.
+
+        ### Raises
+        -   ValueError if check_mode is not provided.
+        """
+        method_name = inspect.stack()[0][3]
+        self.check_mode = self.params.get("check_mode", None)
+        if self.check_mode is None:
+            msg = f"{self.class_name}.{method_name}: "
+            msg += "check_mode is required."
+            raise ValueError(msg)
+
+    def populate_config(self):
+        """
+        ### Summary
+        Populate ``config`` with the playbook config.
+
+        ### Raises
+        -   ValueError if:
+                -   ``state`` is "merged" or "replaced" and ``config`` is None.
+                -   ``config`` is not a list.
+        """
+        method_name = inspect.stack()[0][3]
+        states_requiring_config = {"merged", "replaced"}
+        self.config = self.params.get("config", None)
+        if self.state in states_requiring_config:
+            if self.config is None:
+                msg = f"{self.class_name}.{method_name}: "
+                msg += "params is missing config parameter."
+                raise ValueError(msg)
+            if not isinstance(self.config, list):
+                msg = f"{self.class_name}.{method_name}: "
+                msg += "expected list type for self.config. "
+                msg += f"got {type(self.config).__name__}"
+                raise ValueError(msg)
+
+    def populate_state(self):
+        """
+        ### Summary
+        Populate ``state`` with the playbook state.
+
+        ### Raises
+        -   ValueError if:
+                -   ``state`` is not provided.
+                -   ``state`` is not a valid state.
+        """
+        method_name = inspect.stack()[0][3]
+
+        valid_states = ["deleted", "merged", "query", "replaced"]
+
+        self.state = self.params.get("state", None)
+        if self.state is None:
+            msg = f"{self.class_name}.{method_name}: "
+            msg += "params is missing state parameter."
+            raise ValueError(msg)
+        if self.state not in valid_states:
+            msg = f"{self.class_name}.{method_name}: "
+            msg += f"Invalid state: {self.state}. "
+            msg += f"Expected one of: {','.join(valid_states)}."
+            raise ValueError(msg)
+
+    def get_have(self):
+        """
+        ### Summary
+        Build ``self.have``, which is a dict containing the current controller
+        fabrics and their details.
+
+        ### Raises
+        -   ``ValueError`` if the controller returns an error when attempting to
+            retrieve the fabric details.
+
+        ### have structure
+
+        ``have`` is a dict, keyed on fabric_name, where each element is a dict
+        with the following structure.
+
+        ```python
+        have = {
+            "fabric_name": "fabric_name",
+            "fabric_config": {
+                "fabricName": "fabric_name",
+                "fabricType": "VXLAN EVPN",
+                "etc...": "etc..."
+            }
+        }
+        ```
+
+        """
+        method_name = inspect.stack()[0][3]  # pylint: disable=unused-variable
+        try:
+            self.have = FabricDetailsByName()
+            # pylint: disable=no-member
+            self.have.rest_send = self.rest_send
+            self.have.results = Results()
+            self.have.refresh()
+            # pylint: enable=no-member
+        except ValueError as error:
+            msg = f"{self.class_name}.{method_name}: "
+            msg += "Controller returned error when attempting to retrieve "
+            msg += "fabric details. "
+            msg += f"Error detail: {error}"
+            raise ValueError(msg) from error
+
+    def get_want(self) -> None:
+        """
+        ### Summary
+        -   Validate the playbook configs.
+        -   Update self.want with the playbook configs.
+
+        ### Raises
+        -   ``ValueError`` if the playbook configs are invalid.
+        """
+        merged_configs = []
+        for config in self.config:
+            try:
+                self._verify_payload(config)
+            except ValueError as error:
+                raise ValueError(f"{error}") from error
+            merged_configs.append(copy.deepcopy(config))
+
+        self.want = []
+        for config in merged_configs:
+            self.want.append(copy.deepcopy(config))
+
+    def get_controller_features(self) -> None:
+        """
+        ### Summary
+
+        -   Retrieve the state of relevant controller features
+        -   Populate self.features
+                -   key: FABRIC_TYPE
+                -   value: True or False
+                        -   True if feature is started for this fabric type
+                        -   False otherwise
+
+        ### Raises
+
+        -   ``ValueError`` if the controller returns an error when attempting to
+            retrieve the controller features.
+        """
+        method_name = inspect.stack()[0][3]
+        self.features = {}
+        # pylint: disable=no-member
+        self.controller_features.rest_send = self.rest_send
+        # pylint: enable=no-member
+        try:
+            self.controller_features.refresh()
+        except ControllerResponseError as error:
+            msg = f"{self.class_name}.{method_name}: "
+            msg += "Controller returned error when attempting to retrieve "
+            msg += "controller features. "
+            msg += f"Error detail: {error}"
+            raise ValueError(msg) from error
+
+        for fabric_type in self.fabric_types.valid_fabric_types:
+            self.fabric_types.fabric_type = fabric_type
+            self.controller_features.filter = self.fabric_types.feature_name
+            self.features[fabric_type] = self.controller_features.started
+
+
+class Deleted(Common):
+    """
+    ### Summary
+    Handle deleted state
+    """
+
+    def __init__(self, params):
+        self.class_name = self.__class__.__name__
+        super().__init__(params)
+
+        self.action = "fabric_delete"
+        self.delete = FabricDelete()
+        self._implemented_states.add("deleted")
+
+        self.log = logging.getLogger(f"dcnm.{self.class_name}")
+
+        msg = "ENTERED Deleted(): "
+        msg += f"state: {self.results.state}, "
+        msg += f"check_mode: {self.results.check_mode}"
+        self.log.debug(msg)
+
+    def commit(self) -> None:
+        """
+        ### Summary
+        delete the fabrics in ``self.want`` that exist on the controller.
+
+        ### Raises
+
+        -   ``ValueError`` if the controller returns an error when attempting to
+            delete the fabrics.
+        """
+        self.get_want()
+        method_name = inspect.stack()[0][3]
+
+        msg = f"ENTERED: {self.class_name}.{method_name}"
+        self.log.debug(msg)
+
+        self.fabric_details = FabricDetailsByName()
+        # pylint: disable=no-member
+        self.fabric_details.rest_send = self.rest_send
+        self.fabric_details.results = Results()
+
+        self.fabric_summary = FabricSummary()
+        self.fabric_summary.rest_send = self.rest_send
+        self.fabric_summary.results = Results()
+
+        self.delete.rest_send = self.rest_send
+        self.delete.fabric_details = self.fabric_details
+        self.delete.fabric_summary = self.fabric_summary
+        self.delete.results = self.results
+        # pylint: enable=no-member
+
+        fabric_names_to_delete = []
+        for want in self.want:
+            fabric_names_to_delete.append(want["FABRIC_NAME"])
+
+        try:
+            self.delete.fabric_names = fabric_names_to_delete
+        except ValueError as error:
+            raise ValueError(f"{error}") from error
+
+        try:
+            self.delete.commit()
+        except ValueError as error:
+            raise ValueError(f"{error}") from error
+
+
+class Merged(Common):
+    """
+    ### Summary
+    Handle merged state.
+
+    ### Raises
+
+    -   ``ValueError`` if:
+        -   The controller features required for the fabric type are not
+            running on the controller.
+        -   The playbook parameters are invalid.
+        -   The controller returns an error when attempting to retrieve
+            the template.
+        -   The controller returns an error when attempting to retrieve
+            the fabric details.
+        -   The controller returns an error when attempting to create
+            the fabric.
+        -   The controller returns an error when attempting to update
+            the fabric.
+    """
+
+    def __init__(self, params):
+        self.class_name = self.__class__.__name__
+        super().__init__(params)
+        method_name = inspect.stack()[0][3]  # pylint: disable=unused-variable
+
+        self.action = "fabric_create"
+        self.log = logging.getLogger(f"dcnm.{self.class_name}")
+
+        self.fabric_details = FabricDetailsByName()
+        self.fabric_summary = FabricSummary()
+        self.fabric_create = FabricCreateBulk()
+        self.fabric_types = FabricTypes()
+        self.fabric_update = FabricUpdateBulk()
+        self.template = TemplateGet()
+
+        msg = f"ENTERED Merged.{method_name}: "
+        msg += f"state: {self.state}, "
+        msg += f"check_mode: {self.check_mode}"
+        self.log.debug(msg)
+
+        self.need_create = []
+        self.need_update = []
+
+        self._implemented_states.add("merged")
+
+    def get_need(self):
+        """
+        ### Summary
+        Build ``self.need`` for merged state.
+
+        ### Raises
+        -   ``ValueError`` if:
+            -   The controller features required for the fabric type are not
+                running on the controller.
+            -   The playbook parameters are invalid.
+            -   The controller returns an error when attempting to retrieve
+                the template.
+            -   The controller returns an error when attempting to retrieve
+                the fabric details.
+        """
+        # pylint: disable=too-many-branches
+        method_name = inspect.stack()[0][3]
+        self.payloads = {}
+        for want in self.want:
+
+            fabric_name = want.get("FABRIC_NAME", None)
+            fabric_type = want.get("FABRIC_TYPE", None)
+
+            if self.features[fabric_type] is False:
+                msg = f"{self.class_name}.{method_name}: "
+                msg += f"Features required for fabric {fabric_name} "
+                msg += f"of type {fabric_type} are not running on the "
+                msg += "controller. Review controller settings at "
+                msg += "Fabric Controller -> Admin -> System Settings -> "
+                msg += "Feature Management"
+                raise ValueError(msg)
+
+            try:
+                self._verify_playbook_params.config_playbook = want
+            except TypeError as error:
+                raise ValueError(f"{error}") from error
+
+            try:
+                self.fabric_types.fabric_type = fabric_type
+            except ValueError as error:
+                raise ValueError(f"{error}") from error
+
+            try:
+                template_name = self.fabric_types.template_name
+            except ValueError as error:
+                raise ValueError(f"{error}") from error
+
+            self.template.rest_send = self.rest_send
+            self.template.template_name = template_name
+
+            try:
+                self.template.refresh()
+            except ValueError as error:
+                raise ValueError(f"{error}") from error
+            except ControllerResponseError as error:
+                msg = f"{self.class_name}.{method_name}: "
+                msg += "Controller returned error when attempting to retrieve "
+                msg += f"template: {template_name}. "
+                msg += f"Error detail: {error}"
+                raise ValueError(msg) from error
+
+            try:
+                self._verify_playbook_params.template = self.template.template
+            except TypeError as error:
+                raise ValueError(f"{error}") from error
+
+            # Append to need_create if the fabric does not exist.
+            # Otherwise, append to need_update.
+            if fabric_name not in self.have.all_data:
+                try:
+                    self._verify_playbook_params.config_controller = None
+                except TypeError as error:
+                    raise ValueError(f"{error}") from error
+
+                if self.params.get("skip_validation") is False:
+                    try:
+                        self._verify_playbook_params.commit()
+                    except ValueError as error:
+                        raise ValueError(f"{error}") from error
+                else:
+                    msg = f"{self.class_name}.{method_name}: "
+                    msg += "skip_validation: "
+                    msg += f"{self.params.get('skip_validation')}, "
+                    msg += "skipping parameter validation."
+                    self.log.debug(msg)
+
+                self.need_create.append(want)
+
+            else:
+
+                nv_pairs = self.have.all_data[fabric_name]["nvPairs"]
+                try:
+                    self._verify_playbook_params.config_controller = nv_pairs
+                except TypeError as error:
+                    raise ValueError(f"{error}") from error
+                if self.params.get("skip_validation") is False:
+                    try:
+                        self._verify_playbook_params.commit()
+                    except (ValueError, KeyError) as error:
+                        raise ValueError(f"{error}") from error
+                else:
+                    msg = f"{self.class_name}.{method_name}: "
+                    msg += "skip_validation: "
+                    msg += f"{self.params.get('skip_validation')}, "
+                    msg += "skipping parameter validation."
+                    self.log.debug(msg)
+
+                self.need_update.append(want)
+        # pylint: enable=too-many-branches
+
+    def commit(self):
+        """
+        ### Summary
+        Commit the merged state request.
+
+        ### Raises
+        -   ``ValueError`` if:
+            -   The controller features required for the fabric type are not
+                running on the controller.
+            -   The playbook parameters are invalid.
+            -   The controller returns an error when attempting to retrieve
+                the template.
+            -   The controller returns an error when attempting to retrieve
+                the fabric details.
+            -   The controller returns an error when attempting to create
+                the fabric.
+            -   The controller returns an error when attempting to update
+        """
+        method_name = inspect.stack()[0][3]  # pylint: disable=unused-variable
+        msg = f"{self.class_name}.{method_name}: entered"
+        self.log.debug(msg)
+
+        self.fabric_details.rest_send = self.rest_send
+        self.fabric_summary.rest_send = self.rest_send
+
+        self.fabric_details.results = Results()
+        self.fabric_summary.results = Results()
+
+        self.get_controller_features()
+        self.get_want()
+        self.get_have()
+        self.get_need()
+        self.send_need_create()
+        self.send_need_update()
+
+    def send_need_create(self) -> None:
+        """
+        ### Summary
+        Build and send the payload to create fabrics specified in the playbook.
+
+        ### Raises
+
+        -   ``ValueError`` if:
+            -   Any payload is invalid.
+            -   The controller returns an error when attempting to create
+                the fabric.
+        """
+        method_name = inspect.stack()[0][3]  # pylint: disable=unused-variable
+        msg = f"{self.class_name}.{method_name}: entered. "
+        msg += f"self.need_create: {json_pretty(self.need_create)}"
+        self.log.debug(msg)
+
+        if len(self.need_create) == 0:
+            msg = f"{self.class_name}.{method_name}: "
+            msg += "No fabrics to create."
+            self.log.debug(msg)
+            return
+
+        self.fabric_create.fabric_details = self.fabric_details
+        self.fabric_create.rest_send = self.rest_send
+        self.fabric_create.results = self.results
+
+        try:
+            self.fabric_create.payloads = self.need_create
+        except ValueError as error:
+            raise ValueError(f"{error}") from error
+
+        try:
+            self.fabric_create.commit()
+        except ValueError as error:
+            raise ValueError(f"{error}") from error
+
+    def send_need_update(self) -> None:
+        """
+        ### Summary
+        Build and send the payload to create fabrics specified in the playbook.
+
+        ### Raises
+
+        -   ``ValueError`` if:
+            -   Any payload is invalid.
+            -   The controller returns an error when attempting to update
+                the fabric.
+        """
+        method_name = inspect.stack()[0][3]  # pylint: disable=unused-variable
+        msg = f"{self.class_name}.{method_name}: entered. "
+        msg += "self.need_update: "
+        msg += f"{json_pretty(self.need_update)}"
+        self.log.debug(msg)
+
+        if len(self.need_update) == 0:
+            msg = f"{self.class_name}.{method_name}: "
+            msg += "No fabrics to update for merged state."
+            self.log.debug(msg)
+            return
+
+        self.fabric_update.fabric_details = self.fabric_details
+        self.fabric_update.fabric_summary = self.fabric_summary
+        self.fabric_update.rest_send = self.rest_send
+        self.fabric_update.results = self.results
+
+        try:
+            self.fabric_update.payloads = self.need_update
+        except ValueError as error:
+            raise ValueError(f"{error}") from error
+
+        try:
+            self.fabric_update.commit()
+        except ValueError as error:
+            raise ValueError(f"{error}") from error
+
+
+class Query(Common):
+    """
+    ### Summary
+    Handle query state.
+
+    ### Raises
+
+    -   ``ValueError`` if:
+        -   The playbook parameters are invalid.
+        -   The controller returns an error when attempting to retrieve
+            the fabric details.
+    """
+
+    def __init__(self, params):
+        self.class_name = self.__class__.__name__
+        super().__init__(params)
+
+        self.action = "fabric_query"
+        self._implemented_states.add("query")
+
+        self.log = logging.getLogger(f"dcnm.{self.class_name}")
+
+        msg = "ENTERED Query(): "
+        msg += f"state: {self.state}, "
+        msg += f"check_mode: {self.check_mode}"
+        self.log.debug(msg)
+
+    def commit(self) -> None:
+        """
+        ### Summary
+        query the fabrics in ``self.want`` that exist on the controller.
+
+        ### Raises
+
+        -   ``ValueError`` if:
+            -   Any fabric names are invalid.
+            -   The controller returns an error when attempting to
+                query the fabrics.
+        """
+        self.fabric_details = FabricDetailsByName()
+        # pylint: disable=no-member
+        self.fabric_details.rest_send = self.rest_send
+        self.fabric_details.results = Results()
+        # pylint: enable=no-member
+
+        self.get_want()
+
+        fabric_query = FabricQuery()
+        fabric_query.fabric_details = self.fabric_details
+        # pylint: disable=no-member
+        fabric_query.rest_send = self.rest_send
+        fabric_query.results = self.results
+        # pylint: enable=no-member
+
+        fabric_names_to_query = []
+        for want in self.want:
+            fabric_names_to_query.append(want["FABRIC_NAME"])
+        try:
+            fabric_query.fabric_names = copy.copy(fabric_names_to_query)
+        except ValueError as error:
+            raise ValueError(f"{error}") from error
+
+        try:
+            fabric_query.commit()
+        except ValueError as error:
+            raise ValueError(f"{error}") from error
+
+
+class Replaced(Common):
+    """
+    ### Summary
+    Handle replaced state.
+
+    ### Raises
+
+    -   ``ValueError`` if:
+        -   The controller features required for the fabric type are not
+            running on the controller.
+        -   The playbook parameters are invalid.
+        -   The controller returns an error when attempting to retrieve
+            the template.
+        -   The controller returns an error when attempting to retrieve
+            the fabric details.
+        -   The controller returns an error when attempting to create
+            the fabric.
+        -   The controller returns an error when attempting to update
+    """
+
+    def __init__(self, params):
+        self.class_name = self.__class__.__name__
+        super().__init__(params)
+        method_name = inspect.stack()[0][3]  # pylint: disable=unused-variable
+
+        self.action = "fabric_replaced"
+        self.log = logging.getLogger(f"dcnm.{self.class_name}")
+
+        self.fabric_details = FabricDetailsByName()
+        self.fabric_replaced = FabricReplacedBulk()
+        self.fabric_summary = FabricSummary()
+        self.fabric_types = FabricTypes()
+        self.merged = None
+        self.need_create = []
+        self.need_replaced = []
+        self.template = TemplateGet()
+        self._implemented_states.add("replaced")
+
+        msg = f"ENTERED Replaced.{method_name}: "
+        msg += f"state: {self.state}, "
+        msg += f"check_mode: {self.check_mode}"
+        self.log.debug(msg)
+
+    def get_need(self):
+        """
+        ### Summary
+        Build ``self.need`` for replaced state.
+
+        ### Raises
+        -   ``ValueError`` if:
+            -   The controller features required for the fabric type are not
+                running on the controller.
+        """
+        method_name = inspect.stack()[0][3]
+        self.payloads = {}
+        for want in self.want:
+
+            fabric_name = want.get("FABRIC_NAME", None)
+            fabric_type = want.get("FABRIC_TYPE", None)
+
+            # If fabrics do not exist on the controller, add them to
+            # need_create.  These will be created by Merged() in
+            # Replaced.send_need_replaced()
+            if fabric_name not in self.have.all_data:
+                self.need_create.append(want)
+                continue
+
+            if self.features[fabric_type] is False:
+                msg = f"{self.class_name}.{method_name}: "
+                msg += f"Features required for fabric {fabric_name} "
+                msg += f"of type {fabric_type} are not running on the "
+                msg += "controller. Review controller settings at "
+                msg += "Fabric Controller -> Admin -> System Settings -> "
+                msg += "Feature Management"
+                raise ValueError(msg)
+
+            self.need_replaced.append(want)
+
+    def commit(self):
+        """
+        ### Summary
+        Commit the replaced state request.
+
+        ### Raises
+
+        -   ``ValueError`` if:
+            -   The controller features required for the fabric type are not
+                running on the controller.
+        """
+        method_name = inspect.stack()[0][3]
+        msg = f"{self.class_name}.{method_name}: entered"
+        self.log.debug(msg)
+
+        # pylint: disable=no-member
+        self.fabric_details.rest_send = self.rest_send
+        self.fabric_summary.rest_send = self.rest_send
+        # pylint: enable=no-member
+
+        self.fabric_details.results = Results()
+        self.fabric_summary.results = Results()
+
+        self.get_controller_features()
+        self.get_want()
+        self.get_have()
+        self.get_need()
+        self.send_need_replaced()
+
+    def send_need_replaced(self) -> None:
+        """
+        ### Summary
+        Build and send the payload to modify fabrics specified in the
+        playbook per replaced state handling.
+
+        ### Raises
+
+        -   ``ValueError`` if:
+            -   Any payload is invalid.
+            -   The controller returns an error when attempting to
+                 update the fabric.
+        """
+        method_name = inspect.stack()[0][3]  # pylint: disable=unused-variable
+        msg = f"{self.class_name}.{method_name}: entered. "
+        msg += "self.need_replaced: "
+        msg += f"{json_pretty(self.need_replaced)}"
+        self.log.debug(msg)
+
+        if len(self.need_create) != 0:
+            self.merged = Merged(self.params)
+            # pylint: disable=no-member
+            self.merged.rest_send = self.rest_send  # pylint: disable=attribute-defined-outside-init
+            self.merged.fabric_details.rest_send = self.rest_send
+            self.merged.fabric_summary.rest_send = self.rest_send
+            self.merged.results = self.results
+            # pylint: disable=no-member
+            self.merged.need_create = self.need_create
+            self.merged.send_need_create()
+
+        if len(self.need_replaced) == 0:
+            msg = f"{self.class_name}.{method_name}: "
+            msg += "No fabrics to update for replaced state."
+            self.log.debug(msg)
+            return
+
+        self.fabric_replaced.fabric_details = self.fabric_details
+        self.fabric_replaced.fabric_summary = self.fabric_summary
+        # pylint: disable=no-member
+        self.fabric_replaced.rest_send = self.rest_send
+        # pylint: enable=no-member
+        self.fabric_replaced.results = self.results
+
+        try:
+            self.fabric_replaced.payloads = self.need_replaced
+        except ValueError as error:
+            raise ValueError(f"{error}") from error
+
+        try:
+            self.fabric_replaced.commit()
+        except ValueError as error:
+            raise ValueError(f"{error}") from error

--- a/lib/ndfc_python/fabric.py
+++ b/lib/ndfc_python/fabric.py
@@ -367,7 +367,7 @@ class Merged(Common):
             fabric_name = want.get("FABRIC_NAME", None)
             fabric_type = want.get("FABRIC_TYPE", None)
 
-            if self.features[fabric_type] is False:
+            if self.features.get("fabric_type") is False:
                 msg = f"{self.class_name}.{method_name}: "
                 msg += f"Features required for fabric {fabric_name} "
                 msg += f"of type {fabric_type} are not running on the "
@@ -701,7 +701,7 @@ class Replaced(Common):
                 self.need_create.append(want)
                 continue
 
-            if self.features[fabric_type] is False:
+            if self.features.get("fabric_type") is False:
                 msg = f"{self.class_name}.{method_name}: "
                 msg += f"Features required for fabric {fabric_name} "
                 msg += f"of type {fabric_type} are not running on the "

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,7 +79,9 @@ nav:
       - controller_info.py: scripts/controller_info.md
       - credentials.py: scripts/credentials.md
       - device_info.py: scripts/device_info.md
+      - fabric_create.py: scripts/fabric_create.md
       - fabric_info.py: scripts/fabric_info.md
+      - fabric_replace.py: scripts/fabric_replace.md
       - image_policy_create.py: scripts/image_policy_create.md
       - image_policy_delete.py: scripts/image_policy_delete.md
       - image_policy_info.py: scripts/image_policy_info.md


### PR DESCRIPTION
1. examples/fabric_create.py

- New example script

2. examples/fabric_replace.py

- New example script

3. lib/ndfc_python/fabric.py

- Merged() and Replaced() - Hardening

4. examples/credentials.py

- minor cleanup

5. docs/scripts/image_policy_create.md

- minor cleanup

6. docs/scripts/fabric_replace.md

Documentation for fabric_replace.py

7. docs/scripts/fabric_create.md

Documentation for fabric_create.py
