### PR TITLE
Documentation fixes

### DIFF
--- a/docs/setup/clone-the-repositories.md
+++ b/docs/setup/clone-the-repositories.md
@@ -2,8 +2,8 @@
 
 We'll need to clone two repositories.
 
-- ndfc-python
-- ansible-dcnm
+- [ndfc-python](https://github.com/allenrobel/ndfc-python)
+- [ansible-dcnm](https://github.com/CiscoDevNet/ansible-dcnm/tree/main)
 
 It's recommended to clone the repositories side-by-side in the directory where you keep your repositories.  We'll use `$HOME/repos` in our examples.
 
@@ -21,9 +21,9 @@ cd $HOME/repos
 git clone https://github.com/CiscoDevNet/ansible-dcnm.git
 ```
 
-Until relative-imports are integrated into the `ansible-dcnm` repository, you'll need to switch branches.
+Until relative-imports are integrated into the `ansible-dcnm` repository, you'll need to switch branches to the `develop` branch (if the branch isn't currently set to `develop`).
 
 ```bash
 cd $HOME/repos/ansible-dcnm
-git switch relative-imports
+git switch develop
 ```

--- a/docs/setup/enable-logging.md
+++ b/docs/setup/enable-logging.md
@@ -8,7 +8,7 @@ export NDFC_LOGGING_CONFIG=$HOME/repos/ndfc-python/lib/ndfc_python/logging_confi
 
 `NDFC_LOGGING_CONFIG` should point to a standard Pyton logging configuration file.  There is an example file in this repository at ``lib/ndfc_python/logging_config.json``.  Below is the contents.
 
-``` json "Example logging configuration file"
+``` json title="Example logging configuration file"
 {
   "version": 1,
   "formatters": {


### PR DESCRIPTION
1. docs/setup/enable-logging.md

- Fix the json content formatting.

2. docs/setup/clone-the-repositories.md

- Add links to the Github repositories

- Update the section on relative-imports now that this has been merged into develop.