### PR TITLE
More documentation fixes

### DIFF
--- a/docs/scripts/fabric_create.md
+++ b/docs/scripts/fabric_create.md
@@ -18,8 +18,7 @@ config:
     REPLICATION_MODE: Ingress
     VRF_VLAN_RANGE: 2000-2299
   - FABRIC_NAME: YourFabric
-    FABRIC_TYPE: LAN_Classic
-    BGP_AS: 65003
+    FABRIC_TYPE: LAN_CLASSIC
 ```
 
 ## Example Usage
@@ -170,8 +169,7 @@ config:
     REPLICATION_MODE: Multicast
     VRF_VLAN_RANGE: 2000-2299
   - FABRIC_NAME: YourFabric
-    FABRIC_TYPE: LAN_Classic
-    BGP_AS: 65003
+    FABRIC_TYPE: LAN_CLASSIC
 ```
 
 ``` bash title="User config changed some MyFabric parameters"

--- a/docs/scripts/fabric_replace.md
+++ b/docs/scripts/fabric_replace.md
@@ -14,6 +14,7 @@ see [dcnm_fabric](https://allenrobel.github.io/dcnm-docpoc/modules/dcnm_fabric/)
 config:
   - FABRIC_NAME: MyFabric
     FABRIC_TYPE: VXLAN_EVPN
+    BGP_AS: 65002
     REPLICATION_MODE: Ingress
   - FABRIC_NAME: YourFabric
     FABRIC_TYPE: LAN_Classic
@@ -48,6 +49,7 @@ export ND_USERNAME=admin
 config:
   - FABRIC_NAME: MyFabric
     FABRIC_TYPE: VXLAN_EVPN
+    BGP_AS: 65002
     REPLICATION_MODE: Multicast
   - FABRIC_NAME: YourFabric
     FABRIC_TYPE: LAN_Classic
@@ -248,7 +250,7 @@ config:
   - FABRIC_NAME: MyFabric
     REPLICATION_MODE: Multicast
     FABRIC_TYPE: VXLAN_EVPN
-    BGP_AS: 65004
+    BGP_AS: 65002
     DEPLOY: False
   - FABRIC_NAME: YourFabric
     FABRIC_TYPE: LAN_CLASSIC

--- a/docs/scripts/fabric_replace.md
+++ b/docs/scripts/fabric_replace.md
@@ -17,7 +17,7 @@ config:
     BGP_AS: 65002
     REPLICATION_MODE: Ingress
   - FABRIC_NAME: YourFabric
-    FABRIC_TYPE: LAN_Classic
+    FABRIC_TYPE: LAN_CLASSIC
     IS_READ_ONLY: False
 ```
 
@@ -52,7 +52,7 @@ config:
     BGP_AS: 65002
     REPLICATION_MODE: Multicast
   - FABRIC_NAME: YourFabric
-    FABRIC_TYPE: LAN_Classic
+    FABRIC_TYPE: LAN_CLASSIC
     IS_READ_ONLY: False
 ```
 


### PR DESCRIPTION
1. docs/scripts/fabric_replace.md

- `BGP_AS` and `FABRIC_TYPE` are a required parameters, even if the fabric already exists.

- - Fix typo (`LAN_Classic`) should be `LAN_CLASSIC`.

2. docs/scripts/fabric_create.md

- Fix typo (`LAN_Classic`) should be `LAN_CLASSIC`.
