### PR TITLE
Network attach library, script, and example config

### DIFF
--- a/docs/scripts/network_attach.md
+++ b/docs/scripts/network_attach.md
@@ -1,0 +1,95 @@
+# network_attach.py
+
+## Description
+
+Attach one or more networks.
+
+## Example configuration file
+
+``` yaml title="config/network_attach.yaml"
+---
+config:
+  - deployment: true
+    detach_switch_ports: []
+    dot1q_vlan: ""
+    extension_values: ""
+    fabric_name: SITE1
+    freeform_config: []
+    instance_values: ""
+    mso_created: false
+    mso_set_vlan: false
+    network_name: ndfc-python-net1
+    serial_number: 96KWEIQE2HC
+    switch_ports:
+      - Ethernet1/2
+    untagged: true
+    tor_ports: []
+    vlan: 2301
+```
+
+## Example Usage
+
+The example below uses environment variables for credentials, so requires
+only the `--config` argument.  See [Running the Example Scripts]
+for details around specifying credentials from the command line, from
+environment variables, from Ansible Vault, or a combination of these
+credentials sources.
+
+[Running the Example Scripts]: ../setup/running-the-example-scripts.md
+
+``` bash
+export ND_DOMAIN=local
+export ND_IP4=10.1.1.1
+export ND_PASSWORD=MySecret
+export ND_USERNAME=admin
+./network_attach.py --config config/network_attach.yaml
+# output not shown
+```
+
+## Example output
+
+### Success
+
+``` bash
+(ndfc-python) arobel@Allen-M4 examples % ./network_attach.py --config config/network_attach.yaml
+Network ndfc-python-net1 attached to fabric SITE1, serial number 96KWEIQE2HC.
+Network ndfc-python-net1 attached to fabric SITE2, serial number 9OW9132EH2M.
+(ndfc-python) arobel@Allen-M4 examples %
+```
+
+### Example Failure Messages
+
+#### Network does not exist
+
+``` bash
+(ndfc-python) arobel@Allen-M4 examples % ./network_attach.py --config test_network_attach.yaml
+Error attaching network. Error detail: NetworkAttach._final_verification: networkName foo does not exist in fabric SITE1. Create it first before calling NetworkAttach.commit
+(ndfc-python) arobel@Allen-M4 examples %
+```
+
+#### Switch serial_number is invalid
+
+``` bash
+(ndfc-python) arobel@Allen-M4 examples % ./network_attach.py --config test_network_attach.yaml
+Invalid Switch Serial Number :96KWEIQE2H
+(ndfc-python) arobel@Allen-M4 examples %
+```
+
+#### Invalid interface
+
+``` bash
+(ndfc-python) arobel@Allen-M4 examples % ./network_attach.py --config test_network_attach.yaml
+Error attaching network. Controller response: {'RETURN_CODE': 200, 'DATA': {'ndfc-python-net1-[96KWEIQE2HC/LE1]': 'Invalid Interfaces in LE1. Invalid interfaces are Po2.'}, 'MESSAGE': 'OK', 'METHOD': 'POST', 'REQUEST_PATH': 'https://192.168.7.7/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/top-down/fabrics/SITE1/networks/attachments'}
+(ndfc-python) arobel@Allen-M4 examples %
+```
+
+#### Invalid value for `untagged`
+
+```bash
+(ndfc-python) arobel@Allen-M4 examples % ./network_attach.py --config test_network_attach.yaml
+1 validation error for NetworkAttachConfigValidator
+config.0.untagged
+  Input should be a valid boolean [type=bool_type, input_value='foo', input_type=str]
+    For further information visit https://errors.pydantic.dev/2.11/v/bool_type
+(ndfc-python) arobel@Allen-M4 examples %
+```

--- a/examples/config/network_attach.yaml
+++ b/examples/config/network_attach.yaml
@@ -1,0 +1,34 @@
+---
+config:
+  - deployment: true
+    detach_switch_ports: []
+    dot1q_vlan: ""
+    extension_values: ""
+    fabric_name: SITE1
+    freeform_config: []
+    instance_values: ""
+    mso_created: false
+    mso_set_vlan: false
+    network_name: ndfc-python-net1
+    serial_number: 96KWEIQE2HC
+    switch_ports:
+      - Ethernet1/2
+    untagged: true
+    tor_ports: []
+    vlan: 2301
+  - deployment: true
+    detach_switch_ports: []
+    dot1q_vlan: ""
+    extension_values: ""
+    fabric_name: SITE2
+    freeform_config: []
+    instance_values: ""
+    mso_created: false
+    mso_set_vlan: false
+    network_name: ndfc-python-net1
+    serial_number: 9OW9132EH2M
+    switch_ports:
+      - Ethernet1/2
+    untagged: true
+    tor_ports: []
+    vlan: 2301

--- a/examples/config/network_create.yaml
+++ b/examples/config/network_create.yaml
@@ -1,16 +1,16 @@
 ---
 config:
-  - fabric_name: MyFabric1
-    network_name: MyNet1
+  - fabric_name: MSD
+    network_name: ndfc-python-net1
     enable_ir: True
-    gateway_ip_address: 10.1.1.1/24
-    network_id: 30005
-    vlan_id: 3005
-    vrf_name: MyVrf1
-  - fabric_name: MyFabric1
-    network_name: MyNet2
+    gateway_ip_address: 192.1.1.1/24
+    network_id: 30001
+    vlan_id: 2301
+    vrf_name: v0
+  - fabric_name: MSD
+    network_name: ndfc-python-net2
     enable_ir: True
-    gateway_ip_address: 10.2.1.1/24
-    network_id: 30006
-    vlan_id: 3006
-    vrf_name: MyVrf2
+    gateway_ip_address: 192.2.1.1/24
+    network_id: 30002
+    vlan_id: 2302
+    vrf_name: v0

--- a/examples/network_attach.py
+++ b/examples/network_attach.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""
+# network_attach.py
+
+## Description
+
+Attach a network
+
+## Usage
+
+1.  Modify PYTHONPATH appropriately for your setup before running this script
+
+``` bash
+export PYTHONPATH=$PYTHONPATH:$HOME/repos/ndfc-python/lib:$HOME/repos/ansible/collections/ansible_collections/cisco/dcnm
+```
+
+2. Optional, to enable logging.
+
+``` bash
+export NDFC_LOGGING_CONFIG=$HOME/repos/ndfc-python/lib/ndfc_python/logging_config.json
+```
+
+3. Edit ./examples/config/network_attach.yaml with desired network values
+
+4. Set credentials via script command line, environment variables, or Ansible Vault
+
+5. Run the script (below we're using command line for credentials)
+
+``` bash
+./examples/network_attach.py \
+    --config ./examples/config/network_attach.yaml \
+    --nd-domain local \
+    --nd-ip4 10.1.1.1 \
+    --nd-password password \
+    --nd-username admin
+
+```
+
+"""
+# pylint: disable=duplicate-code
+import argparse
+import json
+import logging
+import sys
+from logging import config
+
+from ndfc_python.ndfc_python_logger import NdfcPythonLogger
+from ndfc_python.ndfc_python_sender import NdfcPythonSender
+from ndfc_python.network_attach import NetworkAttach
+from ndfc_python.parsers.parser_ansible_vault import parser_ansible_vault
+from ndfc_python.parsers.parser_config import parser_config
+from ndfc_python.parsers.parser_loglevel import parser_loglevel
+from ndfc_python.parsers.parser_nd_domain import parser_nd_domain
+from ndfc_python.parsers.parser_nd_ip4 import parser_nd_ip4
+from ndfc_python.parsers.parser_nd_password import parser_nd_password
+from ndfc_python.parsers.parser_nd_username import parser_nd_username
+from ndfc_python.read_config import ReadConfig
+from ndfc_python.validators.network_attach import NetworkAttachConfigValidator
+from plugins.module_utils.common.response_handler import ResponseHandler
+from plugins.module_utils.common.rest_send_v2 import RestSend
+from plugins.module_utils.common.results import Results
+from pydantic import ValidationError
+
+
+def network_attach(cfg: dict) -> None:
+    """
+    Given a network configuration, create the network.
+    """
+    try:
+        instance = NetworkAttach()
+        instance.rest_send = rest_send
+        instance.results = Results()
+        print(f"ZZZ network_attach: cfg {cfg}")
+        instance.deployment = cfg.get("deployment")
+        instance.detach_switch_ports = cfg.get("detachSwitchPorts", [])
+        instance.dot1q_vlan = cfg.get("dot1qVlan")
+        instance.extension_values = cfg.get("extensionValues", "")
+        instance.fabric_name = cfg.get("fabric", "")
+        instance.freeform_config = cfg.get("freeformConfig", [])
+        instance.instance_values = cfg.get("instanceValues", "")
+        instance.mso_created = cfg.get("msoCreated", False)
+        instance.mso_set_vlan = cfg.get("msoSetVlan", False)
+        instance.network_name = cfg.get("networkName")
+        instance.serial_number = cfg.get("serialNumber")
+        instance.switch_ports = cfg.get("switchPorts", [])
+        instance.tor_ports = cfg.get("torPorts", [])
+        instance.untagged = cfg.get("untagged", False)
+        instance.vlan = cfg.get("vlan")
+        instance.commit()
+    except ValueError as error:
+        errmsg = "Error attaching network. "
+        errmsg += f"Error detail: {error}"
+        log.error(errmsg)
+        print(errmsg)
+        return
+
+    result_msg = f"Network {instance.network_name} "
+    result_msg += f"attached to fabric {instance.fabric_name}, "
+    result_msg += f"serial number {instance.serial_number}."
+    log.info(result_msg)
+    print(result_msg)
+
+
+def setup_parser() -> argparse.Namespace:
+    """
+    ### Summary
+
+    Setup script-specific parser
+
+    Returns:
+        argparse.Namespace
+    """
+    parser = argparse.ArgumentParser(
+        parents=[
+            parser_ansible_vault,
+            parser_config,
+            parser_loglevel,
+            parser_nd_domain,
+            parser_nd_ip4,
+            parser_nd_password,
+            parser_nd_username,
+        ],
+        description="DESCRIPTION: Create a network.",
+    )
+    return parser.parse_args()
+
+
+args = setup_parser()
+NdfcPythonLogger()
+log = logging.getLogger("ndfc_python.main")
+log.setLevel = args.loglevel
+
+try:
+    config = ReadConfig()
+    config.filename = args.config
+    config.commit()
+except ValueError as error:
+    msg = f"Exiting: Error detail: {error}"
+    log.error(msg)
+    print(msg)
+    sys.exit(1)
+
+try:
+    validator = NetworkAttachConfigValidator(**config.contents)
+except ValidationError as error:
+    msg = f"{error}"
+    log.error(msg)
+    print(msg)
+    sys.exit(1)
+
+try:
+    ndfc_sender = NdfcPythonSender()
+    ndfc_sender.args = args
+    ndfc_sender.commit()
+except ValueError as error:
+    msg = f"Exiting.  Error detail: {error}"
+    log.error(msg)
+    print(msg)
+    sys.exit(1)
+
+rest_send = RestSend({})
+rest_send.sender = ndfc_sender.sender
+rest_send.response_handler = ResponseHandler()
+rest_send.timeout = 2
+rest_send.send_interval = 5
+
+params_list = json.loads(validator.model_dump_json()).get("config", {})
+
+for params in params_list:
+    network_attach(params)

--- a/examples/network_attach.py
+++ b/examples/network_attach.py
@@ -92,6 +92,15 @@ def network_attach(cfg: dict) -> None:
         print(errmsg)
         return
 
+    if instance.rest_send.response_current.get("RESULT_CODE") not in (200, 201):
+        if instance.rest_send.response_current.get("DATA", {}).get("message"):
+            errmsg = instance.rest_send.response_current.get("DATA", {}).get("message")
+        else:
+            errmsg = "Error attaching network. "
+            errmsg += f"Controller response: {instance.rest_send.response_current}"
+        log.error(errmsg)
+        print(errmsg)
+        return
     result_msg = f"Network {instance.network_name} "
     result_msg += f"attached to fabric {instance.fabric_name}, "
     result_msg += f"serial number {instance.serial_number}."

--- a/examples/network_attach.py
+++ b/examples/network_attach.py
@@ -69,7 +69,6 @@ def network_attach(cfg: dict) -> None:
         instance = NetworkAttach()
         instance.rest_send = rest_send
         instance.results = Results()
-        print(f"ZZZ network_attach: cfg {cfg}")
         instance.deployment = cfg.get("deployment")
         instance.detach_switch_ports = cfg.get("detachSwitchPorts", [])
         instance.dot1q_vlan = cfg.get("dot1qVlan")

--- a/examples/network_attach.py
+++ b/examples/network_attach.py
@@ -42,7 +42,6 @@ import argparse
 import json
 import logging
 import sys
-from logging import config
 
 from ndfc_python.ndfc_python_logger import NdfcPythonLogger
 from ndfc_python.ndfc_python_sender import NdfcPythonSender
@@ -131,9 +130,9 @@ log = logging.getLogger("ndfc_python.main")
 log.setLevel = args.loglevel
 
 try:
-    config = ReadConfig()
-    config.filename = args.config
-    config.commit()
+    user_config = ReadConfig()
+    user_config.filename = args.config
+    user_config.commit()
 except ValueError as error:
     msg = f"Exiting: Error detail: {error}"
     log.error(msg)
@@ -141,7 +140,7 @@ except ValueError as error:
     sys.exit(1)
 
 try:
-    validator = NetworkAttachConfigValidator(**config.contents)
+    validator = NetworkAttachConfigValidator(**user_config.contents)
 except ValidationError as error:
     msg = f"{error}"
     log.error(msg)

--- a/lib/ndfc_python/network_attach.py
+++ b/lib/ndfc_python/network_attach.py
@@ -1,0 +1,440 @@
+"""
+# Name
+
+network_attach.py
+
+# Description
+
+Send network create POST requests to the controller
+
+# Payload Example
+
+```json
+[
+    {
+        "networkName": "{{network_1_name}}",
+        "lanAttachList": [
+            {
+                "deployment": "true",
+                "detachSwitchPorts": "",
+                "dot1QVlan": "",
+                "extensionValues": "",
+                "fabric": "{{fabric_1}}",
+                "freeformConfig": "",
+                "instanceValues": "",
+                "msoCreated": "false",
+                "msoSetVlan": "false",
+                "networkName": "{{network_1_name}}",
+                "serialNumber": "{{switch_1_serial_number}}",
+                "switchPorts": "Ethernet1/11",
+                "torPorts": "",
+                "untagged": "true",
+                "vlan": "{{network_1_vlan_id}}",
+            }
+        ]
+    }
+]
+```
+"""
+
+# We are using isort for import sorting.
+# pylint: disable=wrong-import-order
+
+import inspect
+import logging
+
+from ndfc_python.validations import Validations
+from plugins.module_utils.common.properties import Properties
+from plugins.module_utils.fabric.fabric_details_v2 import FabricDetailsByName
+
+
+@Properties.add_rest_send
+@Properties.add_results
+class NetworkAttach:
+    """
+    # Summary
+
+    Attach networks
+
+    ## Example network attach request
+
+    ### See
+
+    ./examples/network_attach.py
+    """
+
+    def __init__(self):
+        self.class_name = __class__.__name__
+        self.log = logging.getLogger(f"ndfc_python.{self.class_name}")
+
+        self.validations = Validations()
+
+        self._rest_send = None
+        self._results = None
+
+        self._payload_set = set()
+        self._payload_set_mandatory = set()
+        self._payload_default = {}
+        self.properties = {}
+
+        self._init_payload_set()
+        self._init_payload_default()
+        self._init_payload()
+
+    def _init_payload_set(self):
+        """
+        set of all payload keys
+        """
+        self._payload_set.add("deployment")
+        self._payload_set.add("detachSwitchPorts")
+        self._payload_set.add("dot1QVlan")
+        self._payload_set.add("extensionValues")
+        self._payload_set.add("fabric")
+        self._payload_set.add("freeformConfig")
+        self._payload_set.add("instanceValues")
+        self._payload_set.add("msoCreated")
+        self._payload_set.add("networkName")
+        self._payload_set.add("serialNumber")
+        self._payload_set.add("switchPorts")
+        self._payload_set.add("torPorts")
+        self._payload_set.add("untagged")
+        self._payload_set.add("vlan")
+
+    def _init_payload_default(self):
+        """
+        set of all default payload keys
+
+        These are keys for which the caller does not have to provide a value
+        unless they specifically want to change them.
+        """
+        # fmt: off
+        self._payload_default["deployment"] = True
+        self._payload_default["detachSwitchPorts"] = ""
+        self._payload_default["dot1QVlan"] = ""
+        self._payload_default["extensionValues"] = ""
+        self._payload_default["freeformConfig"] = ""
+        self._payload_default["instanceValues"] = ""
+        self._payload_default["msoCreated"] = False
+        self._payload_default["msoSetVlan"] = False
+        self._payload_default["switchPorts"] = ""
+        self._payload_default["torPorts"] = ""
+        self._payload_default["untagged"] = True
+        self._payload_default["vlan"] = ""
+        # fmt: on
+
+    def _init_payload(self):
+        self.payload = []
+
+    def _list_to_string(self, lst: list[str]) -> str:
+        """
+        Convert a list of strings to a comma-separated string.
+        Empty list is converted to ""
+        """
+        return ",".join(lst)
+
+    def _freeform_config_to_string(self, lst: list[str]) -> str:
+        """
+        Convert the freeform config list to a return-separated string.
+        Empty list is converted to ""
+        """
+        return "\n".join(lst)
+
+    def _final_verification(self):
+        """
+        final verification of all parameters
+        """
+        method_name = inspect.stack()[0][3]
+        # pylint: disable=no-member
+        if self.rest_send is None:
+            msg = f"{self.class_name}.{method_name}: "
+            msg += f"{self.class_name}.rest_send must be set before calling "
+            msg += f"{self.class_name}.commit"
+            raise ValueError(msg)
+        if self.results is None:
+            msg = f"{self.class_name}.{method_name}: "
+            msg += f"{self.class_name}.results must be set before calling "
+            msg += f"{self.class_name}.commit"
+            raise ValueError(msg)
+        # pylint: enable=no-member
+
+        if self.fabric_exists() is False:
+            msg = f"{self.class_name}.{method_name}: "
+            msg += f"fabric_name {self.fabric_name} "
+            msg += "does not exist on the controller."
+            raise ValueError(msg)
+
+        if self.network_name_exists_in_fabric() is False:
+            msg = f"{self.class_name}.{method_name}: "
+            msg += f"networkName {self.network_name} does not exist "
+            msg += f"in fabric {self.fabric_name}. "
+            msg += f"Create it first before calling {self.class_name}.commit"
+            raise ValueError(msg)
+
+    def fabric_exists(self):
+        """
+        Return True if self.fabric_name exists on the controller.
+        Return False otherwise.
+        """
+        method_name = inspect.stack()[0][3]
+        instance = FabricDetailsByName()
+        # pylint: disable=no-member
+        instance.rest_send = self.rest_send
+        instance.results = self.results
+        # pylint: enable=no-member
+        instance.refresh()
+        msg = f"{self.class_name}.{method_name}: "
+        msg += f"ZZZ self.fabric_name: {self.fabric_name}"
+        print(msg)
+        instance.filter = self.fabric_name
+        if instance.filtered_data is None:
+            return False
+        return True
+
+    def network_name_exists_in_fabric(self):
+        """
+        Return True if networkName exists in the fabric.
+        Else return False
+        """
+        method_name = inspect.stack()[0][3]
+        # TODO: Update when we add endpoint to ansible-dcnm
+        path = "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/top-down/fabrics"
+        path += f"/{self.fabric_name}/networks"
+        verb = "GET"
+
+        # pylint: disable=no-member
+        try:
+            self.rest_send.path = path
+            self.rest_send.verb = verb
+            self.rest_send.commit()
+        except (TypeError, ValueError) as error:
+            msg = f"{self.class_name}.{method_name}: "
+            msg += f"Unable to send {self.rest_send.verb} request to the controller. "
+            msg += f"Error details: {error}"
+            raise ValueError(msg) from error
+        for item in self.rest_send.response_current["DATA"]:
+            if "networkName" not in item:
+                continue
+            if item["networkName"] == self.network_name:
+                return True
+        return False
+
+    def _build_payload(self) -> list[dict]:
+        """
+        Build and return the payload for the API request
+        """
+        _payload = []
+        _payload_item = {}
+        _payload_item["networkName"] = self.network_name
+        _payload_item["lanAttachList"] = []
+        _lan_attach_list_item = {}
+        _lan_attach_list_item["deployment"] = self.deployment
+        _lan_attach_list_item["detachSwitchPorts"] = self.detach_switch_ports
+        _lan_attach_list_item["dot1QVlan"] = self.dot1q_vlan
+        _lan_attach_list_item["extensionValues"] = self.extension_values
+        _lan_attach_list_item["fabric"] = self.fabric_name
+        _lan_attach_list_item["freeformConfig"] = self.freeform_config
+        _lan_attach_list_item["instanceValues"] = self.instance_values
+        _lan_attach_list_item["msoCreated"] = self.mso_created
+        _lan_attach_list_item["msoSetVlan"] = self.mso_set_vlan
+        _lan_attach_list_item["networkName"] = self.network_name
+        _lan_attach_list_item["serialNumber"] = self.serial_number
+        _lan_attach_list_item["switchPorts"] = self.switch_ports
+        _lan_attach_list_item["torPorts"] = self.tor_ports
+        _lan_attach_list_item["untagged"] = self.untagged
+        _lan_attach_list_item["vlan"] = self.vlan
+
+        _payload_item["lanAttachList"].append(_lan_attach_list_item)
+        _payload.append(_payload_item)
+        return _payload
+
+    def commit(self):
+        """
+        Attach a network to a switch
+        """
+        method_name = inspect.stack()[0][3]
+        payload = self._build_payload()
+        self._final_verification()
+
+        print(f"ZZZ {self.class_name}.{method_name}: payload: {payload}")
+        # TODO: Update when we add endpoint to ansible-dcnm
+        path = "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/top-down/fabrics"
+        path += f"/{self.fabric_name}/networks/attachments"
+        verb = "POST"
+
+        # pylint: disable=no-member
+        try:
+            self.rest_send.path = path
+            self.rest_send.verb = verb
+            self.rest_send.payload = payload
+            self.rest_send.commit()
+        except (TypeError, ValueError) as error:
+            msg = f"{self.class_name}.{method_name}: "
+            msg += f"Unable to send {self.rest_send.verb} request to the controller. "
+            msg += f"Error details: {error}"
+            raise ValueError(msg) from error
+
+    @property
+    def deployment(self) -> bool:
+        """
+        return the current value of deployment
+        """
+        return self.properties.get("deployment")
+
+    @deployment.setter
+    def deployment(self, value: bool) -> None:
+        self.properties["deployment"] = value
+
+    @property
+    def detach_switch_ports(self) -> str:
+        """
+        return the current value of detachSwitchPorts
+        """
+        return self.properties.get("detachSwitchPorts")
+
+    @detach_switch_ports.setter
+    def detach_switch_ports(self, value: list[str]) -> None:
+        self.properties["detachSwitchPorts"] = self._list_to_string(value)
+
+    @property
+    def dot1q_vlan(self) -> str:
+        """
+        return the current value of dot1QVlan
+        """
+        return self.properties.get("dot1QVlan")
+
+    @dot1q_vlan.setter
+    def dot1q_vlan(self, value: str) -> None:
+        self.properties["dot1QVlan"] = value
+
+    @property
+    def extension_values(self) -> str:
+        """
+        return the current value of extensionValues
+        """
+        return self.properties.get("extensionValues")
+
+    @extension_values.setter
+    def extension_values(self, value: str) -> None:
+        self.properties["extensionValues"] = value
+
+    @property
+    def fabric_name(self) -> str:
+        """
+        return the current value of fabric
+        """
+        return self.properties.get("fabric")
+
+    @fabric_name.setter
+    def fabric_name(self, value: str) -> None:
+        self.properties["fabric"] = value
+
+    @property
+    def freeform_config(self) -> str:
+        """
+        return the current value of freeformConfig
+        """
+        return self.properties.get("freeformConfig")
+
+    @freeform_config.setter
+    def freeform_config(self, value: list[str]) -> None:
+        self.properties["freeformConfig"] = self._freeform_config_to_string(value)
+
+    @property
+    def instance_values(self) -> str:
+        """
+        return the current value of instanceValues
+        """
+        return self.properties.get("instanceValues")
+
+    @instance_values.setter
+    def instance_values(self, value: str) -> None:
+        self.properties["instanceValues"] = value
+
+    @property
+    def mso_created(self) -> bool:
+        """
+        return the current value of msoCreated
+        """
+        return self.properties.get("msoCreated")
+
+    @mso_created.setter
+    def mso_created(self, value: bool) -> None:
+        self.properties["msoCreated"] = value
+
+    @property
+    def mso_set_vlan(self) -> bool:
+        """
+        return the current value of msoSetVlan
+        """
+        return self.properties.get("msoSetVlan")
+
+    @mso_set_vlan.setter
+    def mso_set_vlan(self, value: bool) -> None:
+        self.properties["msoSetVlan"] = value
+
+    @property
+    def network_name(self) -> str:
+        """
+        return the current value of networkName
+        """
+        return self.properties.get("networkName")
+
+    @network_name.setter
+    def network_name(self, value: str) -> None:
+        self.properties["networkName"] = value
+
+    @property
+    def serial_number(self) -> str:
+        """
+        return the current value of serialNumber
+        """
+        return self.properties.get("serialNumber")
+
+    @serial_number.setter
+    def serial_number(self, value: str) -> None:
+        self.properties["serialNumber"] = value
+
+    @property
+    def switch_ports(self) -> str:
+        """
+        return the current value of switchPorts
+        """
+        return self.properties.get("switchPorts")
+
+    @switch_ports.setter
+    def switch_ports(self, value: list[str]) -> None:
+        self.properties["switchPorts"] = self._list_to_string(value)
+
+    @property
+    def tor_ports(self) -> str:
+        """
+        return the current value of torPorts
+        """
+        return self.properties.get("torPorts")
+
+    @tor_ports.setter
+    def tor_ports(self, value: list[str]) -> None:
+        self.properties["torPorts"] = self._list_to_string(value)
+
+    @property
+    def untagged(self) -> bool:
+        """
+        return the current value of untagged
+        """
+        return self.properties.get("untagged")
+
+    @untagged.setter
+    def untagged(self, value: bool) -> None:
+        self.properties["untagged"] = value
+
+    @property
+    def vlan(self) -> str:
+        """
+        return the current value of vlan
+        """
+        return self.properties.get("vlan")
+
+    @vlan.setter
+    def vlan(self, value: str) -> None:
+        self.validations.verify_vlan(value)
+        self.properties["vlan"] = value

--- a/lib/ndfc_python/network_attach.py
+++ b/lib/ndfc_python/network_attach.py
@@ -175,16 +175,12 @@ class NetworkAttach:
         Return True if self.fabric_name exists on the controller.
         Return False otherwise.
         """
-        method_name = inspect.stack()[0][3]
         instance = FabricDetailsByName()
         # pylint: disable=no-member
         instance.rest_send = self.rest_send
         instance.results = self.results
         # pylint: enable=no-member
         instance.refresh()
-        msg = f"{self.class_name}.{method_name}: "
-        msg += f"ZZZ self.fabric_name: {self.fabric_name}"
-        print(msg)
         instance.filter = self.fabric_name
         if instance.filtered_data is None:
             return False
@@ -256,7 +252,6 @@ class NetworkAttach:
         payload = self._build_payload()
         self._final_verification()
 
-        print(f"ZZZ {self.class_name}.{method_name}: payload: {payload}")
         # TODO: Update when we add endpoint to ansible-dcnm
         path = "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/top-down/fabrics"
         path += f"/{self.fabric_name}/networks/attachments"
@@ -289,6 +284,8 @@ class NetworkAttach:
     def detach_switch_ports(self) -> str:
         """
         return the current value of detachSwitchPorts
+
+        detachSwitchPorts is converted from a list to a comma-separated string in the setter.
         """
         return self.properties.get("detachSwitchPorts")
 
@@ -333,6 +330,8 @@ class NetworkAttach:
     def freeform_config(self) -> str:
         """
         return the current value of freeformConfig
+
+        freeformConfig is converted from a list to a return-separated string in the setter.
         """
         return self.properties.get("freeformConfig")
 
@@ -410,6 +409,8 @@ class NetworkAttach:
     def tor_ports(self) -> str:
         """
         return the current value of torPorts
+
+        torPorts is converted from a list to a comma-separated string in the setter.
         """
         return self.properties.get("torPorts")
 

--- a/lib/ndfc_python/network_attach.py
+++ b/lib/ndfc_python/network_attach.py
@@ -225,7 +225,6 @@ class NetworkAttach:
         _payload = []
         _payload_item = {}
         _payload_item["networkName"] = self.network_name
-        _payload_item["lanAttachList"] = []
         _lan_attach_list_item = {}
         _lan_attach_list_item["deployment"] = self.deployment
         _lan_attach_list_item["detachSwitchPorts"] = self.detach_switch_ports
@@ -243,7 +242,9 @@ class NetworkAttach:
         _lan_attach_list_item["untagged"] = self.untagged
         _lan_attach_list_item["vlan"] = self.vlan
 
-        _payload_item["lanAttachList"].append(_lan_attach_list_item)
+        _lan_attach_list = []
+        _lan_attach_list.append(_lan_attach_list_item)
+        _payload_item["lanAttachList"] = _lan_attach_list
         _payload.append(_payload_item)
         return _payload
 

--- a/lib/ndfc_python/sender_requests.py
+++ b/lib/ndfc_python/sender_requests.py
@@ -144,7 +144,6 @@ class Sender:
         self.url = None
         self._username = environ.get("ND_USERNAME", "admin")
         self._verb = None
-        
 
     def _verify_commit_parameters(self):
         """
@@ -203,7 +202,7 @@ class Sender:
         self.get_url()
         msg = f"{self.class_name}.{method_name}: "
         msg += f"caller: {caller}.  "
-        msg += f"Calling requests with: "
+        msg += "Calling requests with: "
         msg += f"verb {self.verb}, "
         msg += f"path {self.path}, "
         msg += f"url {self.url}, "

--- a/lib/ndfc_python/sender_requests.py
+++ b/lib/ndfc_python/sender_requests.py
@@ -601,13 +601,13 @@ class Sender:
 
     @payload.setter
     def payload(self, value):
-        # method_name = inspect.stack()[0][3]
-        # if not isinstance(value, dict):
-        #     msg = f"{self.class_name}.{method_name}: "
-        #     msg += f"{method_name} must be a dict. "
-        #     msg += f"Got type {type(value).__name__}, "
-        #     msg += f"value {value}."
-        #     raise TypeError(msg)
+        method_name = inspect.stack()[0][3]
+        if not isinstance(value, dict) and not isinstance(value, list):
+            msg = f"{self.class_name}.{method_name}: "
+            msg += f"{method_name} must be a list or dict. "
+            msg += f"Got type {type(value).__name__}, "
+            msg += f"value {value}."
+            raise TypeError(msg)
         self._payload = value
 
     @property

--- a/lib/ndfc_python/sender_requests.py
+++ b/lib/ndfc_python/sender_requests.py
@@ -601,13 +601,13 @@ class Sender:
 
     @payload.setter
     def payload(self, value):
-        method_name = inspect.stack()[0][3]
-        if not isinstance(value, dict):
-            msg = f"{self.class_name}.{method_name}: "
-            msg += f"{method_name} must be a dict. "
-            msg += f"Got type {type(value).__name__}, "
-            msg += f"value {value}."
-            raise TypeError(msg)
+        # method_name = inspect.stack()[0][3]
+        # if not isinstance(value, dict):
+        #     msg = f"{self.class_name}.{method_name}: "
+        #     msg += f"{method_name} must be a dict. "
+        #     msg += f"Got type {type(value).__name__}, "
+        #     msg += f"value {value}."
+        #     raise TypeError(msg)
         self._payload = value
 
     @property

--- a/lib/ndfc_python/validators/network_attach.py
+++ b/lib/ndfc_python/validators/network_attach.py
@@ -1,0 +1,35 @@
+from pydantic import BaseModel, Field, PositiveInt, StrictBool
+
+
+class NetworkAttachConfig(BaseModel):
+    """
+    # Summary
+
+    Base validator for NetworkAttach arguments
+    """
+
+    deployment: StrictBool = Field(default=True)
+    detachSwitchPorts: list[str] = Field(alias="detach_switch_ports", default=[])
+    dot1QVlan: PositiveInt | str = Field(alias="dot1q_vlan", default="")
+    extensionValues: str = Field(alias="extension_values", default="")
+    fabric: str = Field(..., alias="fabric_name")
+    freeformConfig: list[str] = Field(alias="freeform_config", default=[])
+    instanceValues: str = Field(alias="instance_values", default="")
+    msoCreated: StrictBool = Field(alias="mso_created", default=False)
+    msoSetVlan: StrictBool = Field(alias="mso_set_vlan", default=False)
+    networkName: str = Field(..., alias="network_name")
+    serialNumber: str = Field(..., alias="serial_number")
+    switchPorts: list[str] = Field(alias="switch_ports", default=[])
+    torPorts: list[str] = Field(alias="tor_ports", default=[])
+    untagged: StrictBool = Field(default=True)
+    vlan: PositiveInt | str = Field(default="")
+
+
+class NetworkAttachConfigValidator(BaseModel):
+    """
+    # Summary
+
+    config is a list of NetworkAttachConfig
+    """
+
+    config: list[NetworkAttachConfig]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -93,6 +93,7 @@ nav:
       - interface_access_create.py: scripts/interface_access_create.md
       - maintenance_mode.py: scripts/maintenance_mode.md
       - maintenance_mode_info.py: scripts/maintenance_mode_info.md
+      - network_attach.py: scripts/network_attach.md
       - network_create.py: scripts/network_create.md
       - network_delete.py: scripts/network_delete.md
       - reachability.py: scripts/reachability.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "isort>=6.0.1",
     "mkdocs>=1.6.1",
     "mkdocs-material>=9.6.17",
+    "mypy>=1.17.1",
     "pydantic>=2.11.7",
     "pylint>=3.3.8",
     "requests>=2.32.5",

--- a/uv.lock
+++ b/uv.lock
@@ -386,6 +386,32 @@ wheels = [
 ]
 
 [[package]]
+name = "mypy"
+version = "1.17.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mypy-extensions" },
+    { name = "pathspec" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8e/22/ea637422dedf0bf36f3ef238eab4e455e2a0dcc3082b5cc067615347ab8e/mypy-1.17.1.tar.gz", hash = "sha256:25e01ec741ab5bb3eec8ba9cdb0f769230368a22c959c4937360efb89b7e9f01", size = 3352570, upload-time = "2025-07-31T07:54:19.204Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/82/aec2fc9b9b149f372850291827537a508d6c4d3664b1750a324b91f71355/mypy-1.17.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:93378d3203a5c0800c6b6d850ad2f19f7a3cdf1a3701d3416dbf128805c6a6a7", size = 11075338, upload-time = "2025-07-31T07:53:38.873Z" },
+    { url = "https://files.pythonhosted.org/packages/07/ac/ee93fbde9d2242657128af8c86f5d917cd2887584cf948a8e3663d0cd737/mypy-1.17.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:15d54056f7fe7a826d897789f53dd6377ec2ea8ba6f776dc83c2902b899fee81", size = 10113066, upload-time = "2025-07-31T07:54:14.707Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/68/946a1e0be93f17f7caa56c45844ec691ca153ee8b62f21eddda336a2d203/mypy-1.17.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:209a58fed9987eccc20f2ca94afe7257a8f46eb5df1fb69958650973230f91e6", size = 11875473, upload-time = "2025-07-31T07:53:14.504Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/0f/478b4dce1cb4f43cf0f0d00fba3030b21ca04a01b74d1cd272a528cf446f/mypy-1.17.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:099b9a5da47de9e2cb5165e581f158e854d9e19d2e96b6698c0d64de911dd849", size = 12744296, upload-time = "2025-07-31T07:53:03.896Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/70/afa5850176379d1b303f992a828de95fc14487429a7139a4e0bdd17a8279/mypy-1.17.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:fa6ffadfbe6994d724c5a1bb6123a7d27dd68fc9c059561cd33b664a79578e14", size = 12914657, upload-time = "2025-07-31T07:54:08.576Z" },
+    { url = "https://files.pythonhosted.org/packages/53/f9/4a83e1c856a3d9c8f6edaa4749a4864ee98486e9b9dbfbc93842891029c2/mypy-1.17.1-cp313-cp313-win_amd64.whl", hash = "sha256:9a2b7d9180aed171f033c9f2fc6c204c1245cf60b0cb61cf2e7acc24eea78e0a", size = 9593320, upload-time = "2025-07-31T07:53:01.341Z" },
+    { url = "https://files.pythonhosted.org/packages/38/56/79c2fac86da57c7d8c48622a05873eaab40b905096c33597462713f5af90/mypy-1.17.1-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:15a83369400454c41ed3a118e0cc58bd8123921a602f385cb6d6ea5df050c733", size = 11040037, upload-time = "2025-07-31T07:54:10.942Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/c3/adabe6ff53638e3cad19e3547268482408323b1e68bf082c9119000cd049/mypy-1.17.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:55b918670f692fc9fba55c3298d8a3beae295c5cded0a55dccdc5bbead814acd", size = 10131550, upload-time = "2025-07-31T07:53:41.307Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/c5/2e234c22c3bdeb23a7817af57a58865a39753bde52c74e2c661ee0cfc640/mypy-1.17.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:62761474061feef6f720149d7ba876122007ddc64adff5ba6f374fda35a018a0", size = 11872963, upload-time = "2025-07-31T07:53:16.878Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/26/c13c130f35ca8caa5f2ceab68a247775648fdcd6c9a18f158825f2bc2410/mypy-1.17.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c49562d3d908fd49ed0938e5423daed8d407774a479b595b143a3d7f87cdae6a", size = 12710189, upload-time = "2025-07-31T07:54:01.962Z" },
+    { url = "https://files.pythonhosted.org/packages/82/df/c7d79d09f6de8383fe800521d066d877e54d30b4fb94281c262be2df84ef/mypy-1.17.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:397fba5d7616a5bc60b45c7ed204717eaddc38f826e3645402c426057ead9a91", size = 12900322, upload-time = "2025-07-31T07:53:10.551Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/98/3d5a48978b4f708c55ae832619addc66d677f6dc59f3ebad71bae8285ca6/mypy-1.17.1-cp314-cp314-win_amd64.whl", hash = "sha256:9d6b20b97d373f41617bd0708fd46aa656059af57f2ef72aa8c7d6a2b73b74ed", size = 9751879, upload-time = "2025-07-31T07:52:56.683Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/f3/8fcd2af0f5b806f6cf463efaffd3c9548a28f84220493ecd38d127b6b66d/mypy-1.17.1-py3-none-any.whl", hash = "sha256:a9f52c0351c21fe24c21d8c0eb1f62967b262d6729393397b6f443c3b773c3b9", size = 2283411, upload-time = "2025-07-31T07:53:24.664Z" },
+]
+
+[[package]]
 name = "mypy-extensions"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -404,6 +430,7 @@ dependencies = [
     { name = "isort" },
     { name = "mkdocs" },
     { name = "mkdocs-material" },
+    { name = "mypy" },
     { name = "pydantic" },
     { name = "pylint" },
     { name = "requests" },
@@ -416,6 +443,7 @@ requires-dist = [
     { name = "isort", specifier = ">=6.0.1" },
     { name = "mkdocs", specifier = ">=1.6.1" },
     { name = "mkdocs-material", specifier = ">=9.6.17" },
+    { name = "mypy", specifier = ">=1.17.1" },
     { name = "pydantic", specifier = ">=2.11.7" },
     { name = "pylint", specifier = ">=3.3.8" },
     { name = "requests", specifier = ">=2.32.5" },


### PR DESCRIPTION
This PR adds a library, script and example config for network attachments.

Because the network attach payload is a list, this PR also relaxes the payload property in Sender() class to accept any value (list or dict).  We should probably restrict it to either list or dict but, for now, let's just go with not checking the type.