### PR TITLE
Examine RETURN_CODE rather than RESULT_CODE

### DIFF
--- a/examples/network_attach.py
+++ b/examples/network_attach.py
@@ -92,7 +92,7 @@ def network_attach(cfg: dict) -> None:
         print(errmsg)
         return
 
-    if instance.rest_send.response_current.get("RESULT_CODE") not in (200, 201):
+    if instance.rest_send.response_current.get("RETURN_CODE") not in (200, 201):
         if instance.rest_send.response_current.get("DATA", {}).get("message"):
             errmsg = instance.rest_send.response_current.get("DATA", {}).get("message")
         else:

--- a/lib/ndfc_python/network_attach.py
+++ b/lib/ndfc_python/network_attach.py
@@ -72,58 +72,7 @@ class NetworkAttach:
         self._rest_send = None
         self._results = None
 
-        self._payload_set = set()
-        self._payload_set_mandatory = set()
-        self._payload_default = {}
         self.properties = {}
-
-        self._init_payload_set()
-        self._init_payload_default()
-        self._init_payload()
-
-    def _init_payload_set(self):
-        """
-        set of all payload keys
-        """
-        self._payload_set.add("deployment")
-        self._payload_set.add("detachSwitchPorts")
-        self._payload_set.add("dot1QVlan")
-        self._payload_set.add("extensionValues")
-        self._payload_set.add("fabric")
-        self._payload_set.add("freeformConfig")
-        self._payload_set.add("instanceValues")
-        self._payload_set.add("msoCreated")
-        self._payload_set.add("networkName")
-        self._payload_set.add("serialNumber")
-        self._payload_set.add("switchPorts")
-        self._payload_set.add("torPorts")
-        self._payload_set.add("untagged")
-        self._payload_set.add("vlan")
-
-    def _init_payload_default(self):
-        """
-        set of all default payload keys
-
-        These are keys for which the caller does not have to provide a value
-        unless they specifically want to change them.
-        """
-        # fmt: off
-        self._payload_default["deployment"] = True
-        self._payload_default["detachSwitchPorts"] = ""
-        self._payload_default["dot1QVlan"] = ""
-        self._payload_default["extensionValues"] = ""
-        self._payload_default["freeformConfig"] = ""
-        self._payload_default["instanceValues"] = ""
-        self._payload_default["msoCreated"] = False
-        self._payload_default["msoSetVlan"] = False
-        self._payload_default["switchPorts"] = ""
-        self._payload_default["torPorts"] = ""
-        self._payload_default["untagged"] = True
-        self._payload_default["vlan"] = ""
-        # fmt: on
-
-    def _init_payload(self):
-        self.payload = []
 
     def _list_to_string(self, lst: list[str]) -> str:
         """


### PR DESCRIPTION
1. examples/network_attach.py

The script was indicating failure in the case of success due to RESULT_CODE being examined (RESULT_CODE does not exist in the controller responses).

Fix is to examine RETURN_CODE instead.

2. lib/ndfc_python/network_attach.py

Remove unused code.