### PR TITLE
VRF Lite (extensionValues) should be a list

### DIFF
--- a/docs/scripts/vrf_attach.md
+++ b/docs/scripts/vrf_attach.md
@@ -9,19 +9,23 @@ Attach one or more VRFs.
 ``` yaml title="config/vrf_attach.yaml"
 ---
 config:
+  # Topology
   # LE1--SP1--BG1---BG2--SP2--LE2
+
+  # SITE1
+
   # BG1 - Border Gateway
   - deployment: true
     extension_values:
-      auto_vrf_lite_flag: true
-      dot1q_id: "3"
-      if_name: Ethernet1/1
-      ip_mask: "10.33.0.1/30"
-      ipv6_mask: "2010::10:33:0:1/64"
-      neighbor_asn: "65002"
-      neighbor_ip: 10.33.0.2
-      ipv6_neighbor: "2010::10:33:0:2"
-      peer_vrf_name: ndfc-python-vrf1
+      - auto_vrf_lite_flag: true
+        dot1q_id: "3"
+        if_name: Ethernet1/1
+        ip_mask: "10.33.0.1/30"
+        ipv6_mask: "2010::10:33:0:1/64"
+        neighbor_asn: "65002"
+        neighbor_ip: 10.33.0.2
+        ipv6_neighbor: "2010::10:33:0:2"
+        peer_vrf_name: ndfc-python-vrf1
     fabric_name: SITE1
     freeform_config: []
     instance_values:
@@ -33,9 +37,11 @@ config:
     serial_number: 9IMIT2HLNO2
     vlan: 2001
     vrf_name: ndfc-python-vrf1
+
   # LE1 - Leaf
   - deployment: true
-    extension_values: {}
+    extension_values:
+      - {}
     fabric_name: SITE1
     freeform_config: []
     instance_values:
@@ -48,18 +54,20 @@ config:
     vlan: 2001
     vrf_name: ndfc-python-vrf1
 
+  # SITE2
+
   # BG2 - Border Gateway
   - deployment: true
     extension_values:
-      auto_vrf_lite_flag: true
-      dot1q_id: "3"
-      if_name: Ethernet1/1
-      ip_mask: "10.33.0.2/30"
-      ipv6_mask: "2010::10:33:0:2/64"
-      neighbor_asn: "65001"
-      neighbor_ip: 10.33.0.1
-      ipv6_neighbor: "2010::10:33:0:1"
-      peer_vrf_name: ndfc-python-vrf1
+      - auto_vrf_lite_flag: true
+        dot1q_id: "3"
+        if_name: Ethernet1/1
+        ip_mask: "10.33.0.2/30"
+        ipv6_mask: "2010::10:33:0:2/64"
+        neighbor_asn: "65001"
+        neighbor_ip: 10.33.0.1
+        ipv6_neighbor: "2010::10:33:0:1"
+        peer_vrf_name: ndfc-python-vrf1
     fabric_name: SITE2
     freeform_config: []
     instance_values:
@@ -71,9 +79,11 @@ config:
     serial_number: 9Q3FOROSWIP
     vlan: 2001
     vrf_name: ndfc-python-vrf1
+
   # LE2 - Leaf
   - deployment: true
-    extension_values: {}
+    extension_values:
+      - {}
     fabric_name: SITE2
     freeform_config: []
     instance_values:

--- a/examples/config/vrf_attach.yaml
+++ b/examples/config/vrf_attach.yaml
@@ -2,15 +2,15 @@
 config:
   - deployment: true
     extension_values:
-      auto_vrf_lite_flag: true
-      dot1q_id: "3"
-      if_name: Ethernet1/1
-      ip_mask: "10.33.0.1/30"
-      ipv6_mask: "2010::10:33:0:1/64"
-      neighbor_asn: "65002"
-      neighbor_ip: 10.33.0.2
-      ipv6_neighbor: "2010::10:33:0:2"
-      peer_vrf_name: ndfc-python-vrf1
+      - auto_vrf_lite_flag: true
+        dot1q_id: "3"
+        if_name: Ethernet1/1
+        ip_mask: "10.33.0.1/30"
+        ipv6_mask: "2010::10:33:0:1/64"
+        neighbor_asn: "65002"
+        neighbor_ip: 10.33.0.2
+        ipv6_neighbor: "2010::10:33:0:2"
+        peer_vrf_name: ndfc-python-vrf1
     fabric_name: SITE1
     freeform_config: []
     instance_values:
@@ -22,8 +22,11 @@ config:
     serial_number: 9IMIT2HLNO2
     vlan: 2001
     vrf_name: ndfc-python-vrf1
+
+  # LE1 - Leaf
   - deployment: true
-    extension_values: {}
+    extension_values:
+      - {}
     fabric_name: SITE1
     freeform_config: []
     instance_values:
@@ -36,17 +39,20 @@ config:
     vlan: 2001
     vrf_name: ndfc-python-vrf1
 
+  # SITE2
+
+  # BG2 - Border Gateway
   - deployment: true
     extension_values:
-      auto_vrf_lite_flag: true
-      dot1q_id: "3"
-      if_name: Ethernet1/1
-      ip_mask: "10.33.0.2/30"
-      ipv6_mask: "2010::10:33:0:2/64"
-      neighbor_asn: "65001"
-      neighbor_ip: 10.33.0.1
-      ipv6_neighbor: "2010::10:33:0:1"
-      peer_vrf_name: ndfc-python-vrf1
+      - auto_vrf_lite_flag: true
+        dot1q_id: "3"
+        if_name: Ethernet1/1
+        ip_mask: "10.33.0.2/30"
+        ipv6_mask: "2010::10:33:0:2/64"
+        neighbor_asn: "65001"
+        neighbor_ip: 10.33.0.1
+        ipv6_neighbor: "2010::10:33:0:1"
+        peer_vrf_name: ndfc-python-vrf1
     fabric_name: SITE2
     freeform_config: []
     instance_values:
@@ -58,8 +64,11 @@ config:
     serial_number: 9Q3FOROSWIP
     vlan: 2001
     vrf_name: ndfc-python-vrf1
+
+  # LE2 - Leaf
   - deployment: true
-    extension_values: {}
+    extension_values:
+      - {}
     fabric_name: SITE2
     freeform_config: []
     instance_values:

--- a/lib/ndfc_python/validators/vrf_attach.py
+++ b/lib/ndfc_python/validators/vrf_attach.py
@@ -99,7 +99,7 @@ class VrfAttachConfig(BaseModel):
 
     deployment: StrictBool = Field(default=True)
 
-    extensionValues: ExtensionValues | str = Field(alias="extension_values", default="")
+    extensionValues: list[ExtensionValues | str] = Field(alias="extension_values", default=[""])
     fabric: str = Field(..., alias="fabric_name")
     freeformConfig: list[str] = Field(alias="freeform_config", default=[])
     instanceValues: InstanceValues = Field(alias="instance_values", default=InstanceValues().model_dump())

--- a/lib/ndfc_python/validators/vrf_attach.py
+++ b/lib/ndfc_python/validators/vrf_attach.py
@@ -99,7 +99,7 @@ class VrfAttachConfig(BaseModel):
 
     deployment: StrictBool = Field(default=True)
 
-    extensionValues: list[ExtensionValues | str] = Field(alias="extension_values", default=[""])
+    extensionValues: list[ExtensionValues | dict] = Field(alias="extension_values", default=[])
     fabric: str = Field(..., alias="fabric_name")
     freeformConfig: list[str] = Field(alias="freeform_config", default=[])
     instanceValues: InstanceValues = Field(alias="instance_values", default=InstanceValues().model_dump())

--- a/lib/ndfc_python/vrf_attach.py
+++ b/lib/ndfc_python/vrf_attach.py
@@ -233,15 +233,16 @@ class VrfAttach:
         return self.properties.get("extensionValues")
 
     @extension_values.setter
-    def extension_values(self, value: dict) -> None:
-        inner: dict = {}
-        if value.get("IF_NAME") is None or value.get("IF_NAME") == "":
-            self.properties["extensionValues"] = json.dumps(inner)
-            return
-        inner = value.copy()
-        inner["AUTO_VRF_LITE_FLAG"] = str(inner.get("AUTO_VRF_LITE_FLAG", True)).lower()
+    def extension_values(self, value: list) -> None:
+        vrf_lite_conn_list = []
+        for item in value:
+            if item.get("IF_NAME") is None or item.get("IF_NAME") == "":
+                continue
+            vrf_lite_conn_item: dict = item.copy()
+            vrf_lite_conn_item["AUTO_VRF_LITE_FLAG"] = str(vrf_lite_conn_item.get("AUTO_VRF_LITE_FLAG", True)).lower()
+            vrf_lite_conn_list.append(vrf_lite_conn_item)
         outer = {}
-        outer["VRF_LITE_CONN"] = json.dumps({"VRF_LITE_CONN": [inner]})
+        outer["VRF_LITE_CONN"] = json.dumps({"VRF_LITE_CONN": vrf_lite_conn_list})
         outer["MULTISITE_CONN"] = json.dumps({"MULTISITE_CONN": []})
         self.properties["extensionValues"] = json.dumps(outer)
 


### PR DESCRIPTION
This PR adds the capability to define more than one VRF Lite connection since the payload supports a list of VRF Lite connections.

1. lib/ndfc_python/vrf_attach.py

- Update extension_values.setter to expect a list and generate a list of VRF Lite connections from this list.

2. lib/ndfc_python/validators/vrf_attach.py

Modify Pydantic model to enforce a list of ExtensionValues.

3. examples/config/vrf_attach.yaml

Update example config with new list of dict structure

4. docs/scripts/vrf_attach.md

Update the documentation to reflect the new config structure