### PR TITLE
Device info role logical name

### DIFF
--- a/examples/device_info.py
+++ b/examples/device_info.py
@@ -62,9 +62,11 @@ def device_info(inst):
     to a switch ip address, print information about the switch.
     """
     try:
-        print(f"ipv4_address {inst.filter}")
+        print(f"{inst.logical_name}")
+        print(f"  ipv4_address {inst.filter}")
         print(f"  serial_number: {inst.serial_number}")
         print(f"  fabric_name: {inst.fabric_name}")
+        print(f"  role: {inst.role}")
         print(f"  status: {inst.status}")
         print(f"  model: {inst.model}")
         # etc, see additional properties in SwitchDetails()


### PR DESCRIPTION
Output output of examples/device_info.py to include logical_name and role.

New output:

``` bash
(ndfc-python) arobel@Allen-M4 examples % ./device_info.py --config config/s12/device_info.yaml
BG1
  ipv4_address 192.168.12.131
  serial_number: 9T4PSZT7L7J
  fabric_name: SITE1
  role: border gateway
  status: ok
  model: N9K-C9300v
BG2
  ipv4_address 192.168.12.132
  serial_number: 9Z72WV6IVJJ
  fabric_name: SITE2
  role: border gateway
  status: ok
  model: N9K-C9300v
SP1
  ipv4_address 192.168.12.141
  serial_number: 94INFEIHR0S
  fabric_name: SITE1
  role: spine
  status: ok
  model: N9K-C9300v
SP2
  ipv4_address 192.168.12.142
  serial_number: 9NXBJ2HSFUA
  fabric_name: SITE2
  role: spine
  status: ok
  model: N9K-C9300v
LE1
  ipv4_address 192.168.12.151
  serial_number: 9WPLALSNXK6
  fabric_name: SITE1
  role: leaf
  status: ok
  model: N9K-C9300v
LE2
  ipv4_address 192.168.12.152
  serial_number: 9BO7KZF9BH5
  fabric_name: SITE2
  role: leaf
  status: ok
  model: N9K-C9300v
(ndfc-python) arobel@Allen-M4 examples %
```