### PR TITLE
 fabric inventory: script, library, validator, configs

### DIFF
--- a/examples/config/fabric_inventory.yaml
+++ b/examples/config/fabric_inventory.yaml
@@ -1,0 +1,4 @@
+---
+config:
+  - fabric_name: MyFabric1
+  - fabric_name: MyFabric2

--- a/examples/config/s12/fabric_inventory.yaml
+++ b/examples/config/s12/fabric_inventory.yaml
@@ -1,0 +1,4 @@
+---
+config:
+  - fabric_name: SITE1
+  - fabric_name: SITE2

--- a/examples/config/s34/fabric_inventory.yaml
+++ b/examples/config/s34/fabric_inventory.yaml
@@ -1,0 +1,4 @@
+---
+config:
+  - fabric_name: SITE3
+  - fabric_name: SITE4

--- a/examples/fabric_inventory.py
+++ b/examples/fabric_inventory.py
@@ -98,7 +98,7 @@ def setup_parser() -> argparse.Namespace:
 args = setup_parser()
 NdfcPythonLogger()
 log = logging.getLogger("ndfc_python.main")
-log.setLevel = args.loglevel
+log.setLevel(args.loglevel)
 
 try:
     ndfc_config = ReadConfig()
@@ -108,7 +108,7 @@ except ValueError as error:
     msg = f"Exiting: Error detail: {error}"
     print(msg)
     log.error(msg)
-    sys.exit()
+    sys.exit(1)
 
 try:
     validator = FabricInventoryConfigValidator(**ndfc_config.contents)

--- a/examples/fabric_inventory.py
+++ b/examples/fabric_inventory.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""
+# fabric_inventory.py
+## Description
+Get fabric inventory information
+## Usage
+1.  Modify PYTHONPATH appropriately for your setup before running this script
+``` bash
+export PYTHONPATH=$PYTHONPATH:$HOME/repos/ndfc-python/lib:$HOME/repos
+/ansible/collections/ansible_collections/cisco/dcnm
+```
+2. Optional, to enable logging.
+``` bash
+export NDFC_LOGGING_CONFIG=$HOME/repos/ndfc-python/lib/ndfc_python/logging_config.json
+```
+3. Run the script
+``` bash
+./examples/fabric_inventory.py \
+    --nd-domain local \
+    --nd-ip4 192.168.1.1 \
+    --nd-password password \
+    --nd-username admin
+```
+"""
+import argparse
+import json
+import logging
+import sys
+
+from ndfc_python.common.fabric.fabric_inventory import FabricInventory
+from ndfc_python.ndfc_python_logger import NdfcPythonLogger
+from ndfc_python.ndfc_python_sender import NdfcPythonSender
+from ndfc_python.parsers.parser_ansible_vault import parser_ansible_vault
+from ndfc_python.parsers.parser_config import parser_config
+from ndfc_python.parsers.parser_loglevel import parser_loglevel
+from ndfc_python.parsers.parser_nd_domain import parser_nd_domain
+from ndfc_python.parsers.parser_nd_ip4 import parser_nd_ip4
+from ndfc_python.parsers.parser_nd_password import parser_nd_password
+from ndfc_python.parsers.parser_nd_username import parser_nd_username
+from ndfc_python.read_config import ReadConfig
+from ndfc_python.validators.fabric_inventory import FabricInventoryConfigValidator
+from plugins.module_utils.common.response_handler import ResponseHandler
+from plugins.module_utils.common.rest_send_v2 import RestSend
+from plugins.module_utils.common.results import Results
+from pydantic import ValidationError
+
+
+def fabric_inventory(cfg: dict) -> None:
+    """
+    ### Summary
+
+    Retrieve fabric inventory information
+
+    Args:
+        config (dict): configuration dictionary
+
+    Returns:
+        None
+    """
+    instance = FabricInventory()
+    instance.fabric_name = cfg.get("fabric_name")
+    instance.rest_send = rest_send
+    instance.results = Results()
+    instance.commit()
+    if args.detailed:
+        print(f"Fabric {instance.fabric_name}:")
+        for device in sorted(instance.devices):
+            print(f"  {device}: {json.dumps(instance.inventory.get(device), sort_keys=True, indent=4)}")
+    else:
+        print(f"Fabric {instance.fabric_name}: {sorted(instance.devices)}")
+
+
+def setup_parser() -> argparse.Namespace:
+    """
+    ### Summary
+
+    Setup script-specific parser
+
+    Returns:
+        argparse.Namespace
+    """
+    parser = argparse.ArgumentParser(
+        parents=[
+            parser_ansible_vault,
+            parser_config,
+            parser_loglevel,
+            parser_nd_domain,
+            parser_nd_ip4,
+            parser_nd_password,
+            parser_nd_username,
+        ],
+        description="DESCRIPTION: Retrieve fabric inventory.",
+    )
+    parser.add_argument("--detailed", action="store_true", help="Show detailed fabric inventory information")
+    return parser.parse_args()
+
+
+args = setup_parser()
+NdfcPythonLogger()
+log = logging.getLogger("ndfc_python.main")
+log.setLevel = args.loglevel
+
+try:
+    ndfc_config = ReadConfig()
+    ndfc_config.filename = args.config
+    ndfc_config.commit()
+except ValueError as error:
+    msg = f"Exiting: Error detail: {error}"
+    print(msg)
+    log.error(msg)
+    sys.exit()
+
+try:
+    validator = FabricInventoryConfigValidator(**ndfc_config.contents)
+except ValidationError as error:
+    msg = f"{error}"
+    log.error(msg)
+    print(msg)
+    sys.exit(1)
+
+try:
+    ndfc_sender = NdfcPythonSender()
+    ndfc_sender.args = args
+    ndfc_sender.commit()
+except ValueError as error:
+    msg = f"Exiting.  Error detail: {error}"
+    log.error(msg)
+    print(msg)
+    sys.exit(1)
+
+rest_send = RestSend({})
+rest_send.sender = ndfc_sender.sender
+rest_send.response_handler = ResponseHandler()
+rest_send.results = Results()
+rest_send.timeout = 2
+rest_send.send_interval = 5
+
+params_list = json.loads(validator.model_dump_json()).get("config", {})
+
+for params in params_list:
+    fabric_inventory(params)

--- a/lib/ndfc_python/common/fabric/fabric_inventory.py
+++ b/lib/ndfc_python/common/fabric/fabric_inventory.py
@@ -1,0 +1,214 @@
+import logging
+import sys
+
+from plugins.module_utils.common.properties import Properties
+
+
+@Properties.add_rest_send
+class FabricInventory:
+    """
+    # Summary
+
+    Class to retrieve fabric inventory information.
+
+    ## Usage
+
+    See examples/fabric_inventory.py
+
+    ## Properties
+    - fabric_name (str): name of the fabric to query
+    - rest_send (RestSend): RestSend instance to use for REST calls
+    - results (Results): Results instance to use for result handling
+    """
+    def __init__(self):
+        self.class_name = self.__class__.__name__
+        self.log = logging.getLogger(f"ndfc_python.{self.class_name}")
+        self._committed = False
+        self._fabric_name = None
+        self._inventory = {}
+        self.api_v1 = "/appcenter/cisco/ndfc/api/v1"
+        self.ep_fabrics = f"{self.api_v1}/lan-fabric/rest/control/fabrics"
+
+    def commit(self) -> None:
+        """Get switches for a specific fabric.
+
+        Populates self.fabric_switches:
+            dict keyed on switch_name, containing switch details.
+
+        Example:
+
+            {
+                "VP3": {
+                    "switchRoleEnum": "Leaf",
+                    "vrf": "management",
+                    "fabricTechnology": "VXLANFabric",
+                    "deviceType": "Switch_Fabric",
+                    "fabricId": 4,
+                    "name": null,
+                    "domainID": 0,
+                    "wwn": null,
+                    "membership": null,
+                    "ports": 0,
+                    "model": "N9K-C9300v",
+                    "version": null,
+                    "upTime": 0,
+                    "ipAddress": "192.168.14.153",
+                    "mgmtAddress": null,
+                    "vendor": "Cisco",
+                    "displayHdrs": null,
+                    "displayValues": null,
+                    "colDBId": 0,
+                    "fid": 0,
+                    "isLan": false,
+                    "is_smlic_enabled": false,
+                    "present": true,
+                    "licenseViolation": false,
+                    "managable": true,
+                    "mds": false,
+                    "connUnitStatus": 0,
+                    "standbySupState": 0,
+                    "activeSupSlot": 0,
+                    "unmanagableCause": "",
+                    "lastScanTime": 0,
+                    "fabricName": "SITE4",
+                    "modelType": 0,
+                    "logicalName": "VP3",
+                    "switchDbID": 30820,
+                    "uid": 0,
+                    "release": "10.3(8)",
+                    "location": null,
+                    "contact": null,
+                    "upTimeStr": "01:58:36",
+                    "upTimeNumber": 0,
+                    "network": null,
+                    "nonMdsModel": null,
+                    "numberOfPorts": 0,
+                    "availPorts": 0,
+                    "usedPorts": 0,
+                    "vsanWwn": null,
+                    "vsanWwnName": null,
+                    "swWwn": null,
+                    "swWwnName": null,
+                    "serialNumber": "9EJ4B3H5GJ3",
+                    "domain": null,
+                    "principal": null,
+                    "status": "ok",
+                    "index": 0,
+                    "licenseDetail": null,
+                    "isPmCollect": false,
+                    "sanAnalyticsCapable": false,
+                    "vdcId": 0,
+                    "vdcName": "",
+                    "vdcMac": null,
+                    "fcoeEnabled": false,
+                    "cpuUsage": 0,
+                    "memoryUsage": 0,
+                    "scope": null,
+                    "fex": false,
+                    "health": -1,
+                    "npvEnabled": false,
+                    "linkName": null,
+                    "username": null,
+                    "primaryIP": "",
+                    "primarySwitchDbID": 0,
+                    "secondaryIP": "",
+                    "secondarySwitchDbID": 0,
+                    "isEchSupport": false,
+                    "moduleIndexOffset": 9999,
+                    "sysDescr": "",
+                    "isTrapDelayed": false,
+                    "switchRole": "leaf",
+                    "mode": "Normal",
+                    "hostName": "VP3",
+                    "ipDomain": "",
+                    "systemMode": "Normal",
+                    "waitForSwitchModeChg": false,
+                    "sourceVrf": "management",
+                    "sourceInterface": "mgmt0",
+                    "protoDiscSettings": null,
+                    "operMode": null,
+                    "modules": null,
+                    "fexMap": {},
+                    "isVpcConfigured": true,
+                    "vpcDomain": 1,
+                    "role": "Primary",
+                    "peer": "VP4",
+                    "peerSerialNumber": "9XUGSGI5J1O",
+                    "peerSwitchDbId": 30780,
+                    "peerlinkState": "Peer is OK",
+                    "keepAliveState": "Peer is alive",
+                    "consistencyState": true,
+                    "sendIntf": "Eth1/1",
+                    "recvIntf": "Lo0",
+                    "interfaces": null,
+                    "elementType": null,
+                    "monitorMode": null,
+                    "freezeMode": null,
+                    "cfsSyslogStatus": 1,
+                    "isNonNexus": false,
+                    "swUUIDId": 30670,
+                    "swUUID": "DCNM-UUID-30670",
+                    "swType": null,
+                    "ccStatus": "In-Sync",
+                    "operStatus": "Minor",
+                    "intentedpeerName": "VP4",
+                    "sharedBorder": false,
+                    "isSharedBorder": false
+                },
+                "switch2": {
+                    switch_details
+                }
+            }
+        """
+        verb = "GET"
+        path = f"{self.ep_fabrics}/{self.fabric_name}/inventory/switchesByFabric"
+        # pylint: disable=no-member
+        try:
+            self.rest_send.path = path  # type: ignore[attr-defined]
+            self.rest_send.verb = verb  # type: ignore[attr-defined]
+            self.rest_send.commit()  # type: ignore[attr-defined]
+        except (TypeError, ValueError) as error:
+            msg = f"Unable to send {verb} request to the controller. "
+            msg += f"Error details: {error}"
+            raise ValueError(msg) from error
+        for switch in self.rest_send.response_current.get("DATA", []):  # type: ignore[attr-defined]
+            switch_name = switch.get("logicalName")
+            if switch_name is None:
+                continue
+            self._inventory[switch_name] = switch
+        self._committed = True
+
+    @property
+    def devices(self):
+        """
+        return a list of device names in the fabric inventory
+        """
+        if not self._committed:
+            self.commit()
+        return list(self.inventory.keys())
+
+    @property
+    def inventory(self):
+        """
+        return a list of device names in the inventory
+        """
+        if not self._committed:
+            self.commit()
+        return self._inventory
+
+    @property
+    def fabric_name(self) -> str:
+        """
+        return the current value of fabric
+        """
+        return self._fabric_name
+
+    @fabric_name.setter
+    def fabric_name(self, value: str) -> None:
+        self._fabric_name = value
+
+
+if __name__ == "__main__":
+    print("This is a library of common utilities for ND Python.")
+    print("It is not meant to be executed directly.")
+    sys.exit(1)

--- a/lib/ndfc_python/common/fabric/fabric_inventory.py
+++ b/lib/ndfc_python/common/fabric/fabric_inventory.py
@@ -20,6 +20,7 @@ class FabricInventory:
     - rest_send (RestSend): RestSend instance to use for REST calls
     - results (Results): Results instance to use for result handling
     """
+
     def __init__(self):
         self.class_name = self.__class__.__name__
         self.log = logging.getLogger(f"ndfc_python.{self.class_name}")

--- a/lib/ndfc_python/common/fabric/fabric_inventory.py
+++ b/lib/ndfc_python/common/fabric/fabric_inventory.py
@@ -191,7 +191,7 @@ class FabricInventory:
     @property
     def inventory(self):
         """
-        return a list of device names in the inventory
+        return the fabric inventory dictionary
         """
         if not self._committed:
             self.commit()

--- a/lib/ndfc_python/validators/fabric_inventory.py
+++ b/lib/ndfc_python/validators/fabric_inventory.py
@@ -17,7 +17,7 @@ class FabricInventoryConfigValidator(BaseModel):
     """
     # Summary
 
-    config is a list of VrfCreateConfig
+    config is a list of FabricInventoryConfig
     """
 
     config: List[FabricInventoryConfig]

--- a/lib/ndfc_python/validators/fabric_inventory.py
+++ b/lib/ndfc_python/validators/fabric_inventory.py
@@ -1,0 +1,23 @@
+from typing import List
+
+from pydantic import BaseModel
+
+
+class FabricInventoryConfig(BaseModel):
+    """
+    # Summary
+
+    Base validator for FabricInventory arguments
+    """
+
+    fabric_name: str
+
+
+class FabricInventoryConfigValidator(BaseModel):
+    """
+    # Summary
+
+    config is a list of VrfCreateConfig
+    """
+
+    config: List[FabricInventoryConfig]


### PR DESCRIPTION
The PR adds new functionality in the form of a library to retrieve inventory for a fabric.

1. lib/ndffc_python/validators/fabric_inventory.py

Validator for fabric inventory script configuration

2. lib/ndffc_python/common/fabric/fabric_inventory.py

Libary to retrieve fabric inventory

3. examples/fabric_inventory.py

An example script that leverages the library and validator

4. Configs

4a. Generic config example

examples/config/fabric_inventory.yaml

4b. Config specific to SITE1 / SITE2 in my homelab

examples/config//s12fabric_inventory.yaml

4c. Config specific to SITE3 / SITE4 in my homelab

examples/config//s12fabric_inventory.yaml