### PR TITLE
NetworkAttach: accept switch_name vs serial_number

### DIFF
--- a/examples/config/network_attach.yaml
+++ b/examples/config/network_attach.yaml
@@ -1,6 +1,7 @@
 ---
 config:
-  - deployment: true
+  - switch_name: LE1
+    deployment: true
     detach_switch_ports: []
     dot1q_vlan: ""
     extension_values: ""
@@ -10,13 +11,13 @@ config:
     mso_created: false
     mso_set_vlan: false
     network_name: ndfc-python-net1
-    serial_number: 96KWEIQE2HC
     switch_ports:
       - Ethernet1/2
     untagged: true
     tor_ports: []
     vlan: 2301
-  - deployment: true
+  - switch_name: LE2
+    deployment: true
     detach_switch_ports: []
     dot1q_vlan: ""
     extension_values: ""
@@ -26,7 +27,6 @@ config:
     mso_created: false
     mso_set_vlan: false
     network_name: ndfc-python-net1
-    serial_number: 9OW9132EH2M
     switch_ports:
       - Ethernet1/2
     untagged: true

--- a/examples/config/s12/network_attach.yaml
+++ b/examples/config/s12/network_attach.yaml
@@ -1,28 +1,28 @@
 ---
 config:
   # SITE1 LE1
-  - detach_switch_ports: []
+  - switch_name: LE1
+    detach_switch_ports: []
     dot1q_vlan: ""
     extension_values: ""
     fabric_name: SITE1
     freeform_config: []
     instance_values: ""
     network_name: v1n1
-    serial_number: 96KWEIQE2HC
     switch_ports:
       - Ethernet1/2
     untagged: true
     tor_ports: []
     vlan: 2301
   # SITE2 LE2
-  - detach_switch_ports: []
+  - switch_name: LE2
+    detach_switch_ports: []
     dot1q_vlan: ""
     extension_values: ""
     fabric_name: SITE2
     freeform_config: []
     instance_values: ""
     network_name: v1n1
-    serial_number: 9OW9132EH2M
     switch_ports:
       - Ethernet1/2
     untagged: true

--- a/examples/config/s34/network_attach.yaml
+++ b/examples/config/s34/network_attach.yaml
@@ -1,28 +1,42 @@
 ---
 config:
   # SITE3 LE3
-  - detach_switch_ports: []
+  - switch_name: LE3
+    detach_switch_ports: []
     dot1q_vlan: ""
     extension_values: ""
     fabric_name: SITE3
     freeform_config: []
     instance_values: ""
     network_name: v1n1
-    serial_number: 93M2LB9V37J
     switch_ports:
       - Ethernet1/2
     untagged: true
     tor_ports: []
     vlan: 2301
-  # SITE4 LE4
-  - detach_switch_ports: []
+  # SITE4 VP3
+  - switch_name: VP3
+    detach_switch_ports: []
     dot1q_vlan: ""
     extension_values: ""
     fabric_name: SITE4
     freeform_config: []
     instance_values: ""
     network_name: v1n1
-    serial_number: 9XS0QJEAI69
+    switch_ports:
+      - Ethernet1/2
+    untagged: true
+    tor_ports: []
+    vlan: 2301
+  # SITE4 VP4
+  - switch_name: VP4
+    detach_switch_ports: []
+    dot1q_vlan: ""
+    extension_values: ""
+    fabric_name: SITE4
+    freeform_config: []
+    instance_values: ""
+    network_name: v1n1
     switch_ports:
       - Ethernet1/2
     untagged: true

--- a/examples/network_attach.py
+++ b/examples/network_attach.py
@@ -76,7 +76,7 @@ def network_attach(cfg: dict) -> None:
         instance.freeform_config = cfg.get("freeformConfig", [])
         instance.instance_values = cfg.get("instanceValues", "")
         instance.network_name = cfg.get("networkName")
-        instance.serial_number = cfg.get("serialNumber")
+        instance.switch_name = cfg.get("switch_name")
         instance.switch_ports = cfg.get("switchPorts", [])
         instance.tor_ports = cfg.get("torPorts", [])
         instance.untagged = cfg.get("untagged", False)
@@ -100,7 +100,7 @@ def network_attach(cfg: dict) -> None:
         return
     result_msg = f"Network {instance.network_name} "
     result_msg += f"attached to fabric {instance.fabric_name}, "
-    result_msg += f"serial number {instance.serial_number}."
+    result_msg += f"switch_name {instance.switch_name}."
     log.info(result_msg)
     print(result_msg)
 
@@ -132,7 +132,7 @@ def setup_parser() -> argparse.Namespace:
 args = setup_parser()
 NdfcPythonLogger()
 log = logging.getLogger("ndfc_python.main")
-log.setLevel = args.loglevel
+log.setLevel(args.loglevel)
 
 try:
     user_config = ReadConfig()

--- a/lib/ndfc_python/network_attach.py
+++ b/lib/ndfc_python/network_attach.py
@@ -43,6 +43,7 @@ Send network attach POST requests to the controller
 import inspect
 import logging
 
+from ndfc_python.common.fabric.fabric_inventory import FabricInventory
 from ndfc_python.validations import Validations
 from plugins.module_utils.common.properties import Properties
 from plugins.module_utils.fabric.fabric_details_v2 import FabricDetailsByName
@@ -67,6 +68,7 @@ class NetworkAttach:
         self.class_name = __class__.__name__
         self.log = logging.getLogger(f"ndfc_python.{self.class_name}")
 
+        self.fabric_inventory = FabricInventory()
         self.validations = Validations()
 
         self._rest_send = None
@@ -179,7 +181,13 @@ class NetworkAttach:
         _lan_attach_list_item["freeformConfig"] = self.freeform_config
         _lan_attach_list_item["instanceValues"] = self.instance_values
         _lan_attach_list_item["networkName"] = self.network_name
-        _lan_attach_list_item["serialNumber"] = self.serial_number
+        try:
+            _lan_attach_list_item["serialNumber"] = self.fabric_inventory.switch_name_to_serial_number(self.switch_name)
+        except ValueError as error:
+            msg = f"{self.class_name}._build_payload: "
+            msg += f"Unable to get serial number for switch_name {self.switch_name}. "
+            msg += f"Error details: {error}"
+            raise ValueError(msg) from error
         _lan_attach_list_item["switchPorts"] = self.switch_ports
         _lan_attach_list_item["torPorts"] = self.tor_ports
         _lan_attach_list_item["untagged"] = self.untagged
@@ -196,15 +204,19 @@ class NetworkAttach:
         Attach a network to a switch
         """
         method_name = inspect.stack()[0][3]
-        payload = self._build_payload()
         self._final_verification()
+        # pylint: disable=no-member
+        self.fabric_inventory.fabric_name = self.fabric_name
+        self.fabric_inventory.rest_send = self.rest_send  # type: ignore[attr-defined]
+        self.fabric_inventory.results = self.results  # type: ignore[attr-defined]
+        self.fabric_inventory.commit()
+        payload = self._build_payload()
 
         # TODO: Update when we add endpoint to ansible-dcnm
         path = "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/top-down/fabrics"
         path += f"/{self.fabric_name}/networks/attachments"
         verb = "POST"
 
-        # pylint: disable=no-member
         try:
             self.rest_send.path = path
             self.rest_send.verb = verb
@@ -298,15 +310,15 @@ class NetworkAttach:
         self.properties["networkName"] = value
 
     @property
-    def serial_number(self) -> str:
+    def switch_name(self) -> str:
         """
-        return the current value of serialNumber
+        return the current value of switch_name
         """
-        return self.properties.get("serialNumber")
+        return self.properties.get("switch_name")
 
-    @serial_number.setter
-    def serial_number(self, value: str) -> None:
-        self.properties["serialNumber"] = value
+    @switch_name.setter
+    def switch_name(self, value: str) -> None:
+        self.properties["switch_name"] = value
 
     @property
     def switch_ports(self) -> str:

--- a/lib/ndfc_python/validators/network_attach.py
+++ b/lib/ndfc_python/validators/network_attach.py
@@ -15,7 +15,7 @@ class NetworkAttachConfig(BaseModel):
     freeformConfig: list[str] = Field(alias="freeform_config", default=[])
     instanceValues: str = Field(alias="instance_values", default="")
     networkName: str = Field(..., alias="network_name")
-    serialNumber: str = Field(..., alias="serial_number")
+    switch_name: str
     switchPorts: list[str] = Field(alias="switch_ports", default=[])
     torPorts: list[str] = Field(alias="tor_ports", default=[])
     untagged: StrictBool = Field(default=True)


### PR DESCRIPTION
NetworkAttach: use switch_name as switch specifier

Similar to other recent PRs, this commit modifies the NetworkAttach class to accept a switch_name, rather than a serial_number.

The validator, example script, and config files are also modified accordingly.