### PR TITLE
NetworkAttach: VPC support

### DIFF
--- a/examples/config/network_attach.yaml
+++ b/examples/config/network_attach.yaml
@@ -1,3 +1,6 @@
+# For vPC peers, only one switch of the pair needs to be included.
+# The configuration for the vPC switch must include the peer_switch_name parameter.
+# See VP3 below for an example.
 ---
 config:
   - switch_name: LE1
@@ -26,6 +29,21 @@ config:
     instance_values: ""
     mso_created: false
     mso_set_vlan: false
+    network_name: ndfc-python-net1
+    switch_ports:
+      - Ethernet1/2
+    untagged: true
+    tor_ports: []
+    vlan: 2301
+  # SITE4 VP3/VP4 VPC peers
+  - switch_name: VP3
+    peer_switch_name: VP4
+    detach_switch_ports: []
+    dot1q_vlan: ""
+    extension_values: ""
+    fabric_name: SITE4
+    freeform_config: []
+    instance_values: ""
     network_name: ndfc-python-net1
     switch_ports:
       - Ethernet1/2

--- a/examples/config/s34/network_attach.yaml
+++ b/examples/config/s34/network_attach.yaml
@@ -1,3 +1,6 @@
+# For vPC peers, only one switch of the pair needs to be included.
+# The configuration for the vPC switch must include the peer_switch_name parameter.
+# See VP3 below for an example.
 ---
 config:
   # SITE3 LE3
@@ -14,22 +17,9 @@ config:
     untagged: true
     tor_ports: []
     vlan: 2301
-  # SITE4 VP3
+  # SITE4 VP3/VP4 VPC peers
   - switch_name: VP3
-    detach_switch_ports: []
-    dot1q_vlan: ""
-    extension_values: ""
-    fabric_name: SITE4
-    freeform_config: []
-    instance_values: ""
-    network_name: v1n1
-    switch_ports:
-      - Ethernet1/2
-    untagged: true
-    tor_ports: []
-    vlan: 2301
-  # SITE4 VP4
-  - switch_name: VP4
+    peer_switch_name: VP4
     detach_switch_ports: []
     dot1q_vlan: ""
     extension_values: ""

--- a/examples/network_attach.py
+++ b/examples/network_attach.py
@@ -83,6 +83,7 @@ def network_attach(cfg: dict) -> None:
         instance.freeform_config = cfg.get("freeformConfig", [])
         instance.instance_values = cfg.get("instanceValues", "")
         instance.network_name = network_name
+        instance.peer_switch_name = cfg.get("peer_switch_name")
         instance.switch_name = switch_name
         instance.switch_ports = cfg.get("switchPorts", [])
         instance.tor_ports = cfg.get("torPorts", [])

--- a/lib/ndfc_python/validators/network_attach.py
+++ b/lib/ndfc_python/validators/network_attach.py
@@ -15,6 +15,7 @@ class NetworkAttachConfig(BaseModel):
     freeformConfig: list[str] = Field(alias="freeform_config", default=[])
     instanceValues: str = Field(alias="instance_values", default="")
     networkName: str = Field(..., alias="network_name")
+    peer_switch_name: str = Field(default="")
     switch_name: str
     switchPorts: list[str] = Field(alias="switch_ports", default=[])
     torPorts: list[str] = Field(alias="tor_ports", default=[])


### PR DESCRIPTION
## Pull Request Overview

This PR enhances the `NetworkAttach` class, validator, example script, and example configuration files,  to support VPC (Virtual Port Channel) peers.

Key changes:
- Added VPC peer detection and validation logic
- Modified payload generation to include both VPC peers when applicable
- Update validator to accept a `peer_switch_name` parameter
