### PR TITLE
InterfaceAccess: switch_name specifies switch

### DIFF
--- a/examples/config/interface_access_create.yaml
+++ b/examples/config/interface_access_create.yaml
@@ -1,6 +1,8 @@
 ---
 config:
-  - access_vlan: ""
+  - switch_name: LE1
+    fabric_name: SITE1
+    access_vlan: ""
     admin_state: True
     bpduguard_enabled: True
     desc: "Eth1/2: Connected to HO1"
@@ -11,5 +13,4 @@ config:
     netflow_monitor: ""
     porttype_fast_enabled: True
     ptp: False
-    serial_number: 96KWEIQE2HC
     speed: Auto

--- a/examples/interface_access_create.py
+++ b/examples/interface_access_create.py
@@ -74,13 +74,14 @@ def interface_access_create(config):
         instance.conf = config.get("conf")
         instance.desc = config.get("desc")
         instance.enable_netflow = config.get("enable_netflow")
+        instance.fabric_name = config.get("fabric_name")
         instance.intf_name = config.get("intf_name")
         instance.if_name = config.get("intf_name")
         instance.mtu = config.get("mtu")
         instance.netflow_monitor = config.get("netflow_monitor")
         instance.porttype_fast_enabled = config.get("porttype_fast_enabled")
         instance.ptp = config.get("ptp")
-        instance.serial_number = config.get("serial_number")
+        instance.switch_name = config.get("switch_name")
         instance.speed = config.get("speed")
         result = instance.commit()
     except ValueError as error:
@@ -92,7 +93,8 @@ def interface_access_create(config):
 
     if result.get("RETURN_CODE") == 403 and result.get("MESSAGE") == "Forbidden":
         msg = "Controller response (403 and MESSAGE 'Forbidden') implies "
-        msg += f"that serial_number {instance.serial_number} does not exist."
+        msg += f"that switch_name {instance.switch_name} does not exist "
+        msg += f"in fabric {instance.fabric_name}."
         log.error(msg)
         print(msg)
         return
@@ -105,7 +107,7 @@ def interface_access_create(config):
         return
 
     result_msg = f"Interface {instance.intf_name} "
-    result_msg += f"created on switch {instance.serial_number}"
+    result_msg += f"created on switch {instance.switch_name} ({instance.serial_number})"
     log.info(result_msg)
     print(result_msg)
 

--- a/lib/ndfc_python/validators/interface_access.py
+++ b/lib/ndfc_python/validators/interface_access.py
@@ -16,13 +16,14 @@ class InterfaceAccessCreateConfig(BaseModel):
     conf: Optional[str] = Field(alias="freeform_config", default="")
     desc: Optional[str] = Field(default="")
     enable_netflow: Optional[bool] = Field(default=False)
+    fabric_name: str = Field(...)
     intf_name: str = Field(..., alias="interface_name")
     mtu: Optional[PositiveInt | str] = Field(default="jumbo")
     netflow_monitor: Optional[str] = Field(default="")
     porttype_fast_enabled: Optional[bool] = Field(default=True)
     ptp: Optional[bool] = Field(default=False)
-    serial_number: str = Field(...)
     speed: Optional[PositiveInt | str] = Field(default="Auto")
+    switch_name: str = Field(...)
 
 
 class InterfaceAccessCreateConfigValidator(BaseModel):


### PR DESCRIPTION
Previously, the user had to use serial_number to specify the target switch.  The changes in this commit, remove this constraint and allow the user to specify the switch with switch_name.  switch_name is then translated into serial_number internally.