### PR TITLE
RmSwitchResourceUsage: Use switch_name rather than serial_number to specify target switch

### DIFF
--- a/examples/config/rm_switch_resource_usage.yaml
+++ b/examples/config/rm_switch_resource_usage.yaml
@@ -1,6 +1,8 @@
 ---
 config:
-  - serial_number: 9OW9132EH2M
+  - switch_name: LE1
+    fabric_name: SITE1
     pool_name: ALL
-  - serial_number: 9OW9132EH2M
+  - switch_name: BG1
+    fabric_name: SITE1
     pool_name: TOP_DOWN_VRF_VLAN

--- a/examples/rm_switch_resource_usage.py
+++ b/examples/rm_switch_resource_usage.py
@@ -48,7 +48,8 @@ def rm_switch_resource_usage(config):
     Given a switch resource usage configuration, get the resource usage.
     """
     try:
-        instance.serial_number = config.get("serial_number")
+        instance.switch_name = config.get("switch_name", "")
+        instance.fabric_name = config.get("fabric_name", "")
         instance.filter = config.get("pool_name", "ALL")
         instance.commit()
     except ValueError as error:
@@ -58,7 +59,9 @@ def rm_switch_resource_usage(config):
         print(errmsg)
         return
 
-    result_msg = f"Switch {instance.serial_number} resource usage. Filter: {instance.filter}."
+    result_msg = f"fabric_name {instance.fabric_name}, "
+    result_msg += f"switch_name {instance.switch_name} ({instance.serial_number}), "
+    result_msg += f"filter {instance.filter}, resource usage:\n"
     result_msg += json.dumps(instance.resource_usage, indent=4)
     log.info(result_msg)
     print(result_msg)

--- a/lib/ndfc_python/validators/rm_switch_resource_usage.py
+++ b/lib/ndfc_python/validators/rm_switch_resource_usage.py
@@ -17,8 +17,9 @@ class ResourcePool(Enum):
 class RmSwitchResourceUsageConfig(BaseModel):
     """Base validator for Resource Manager Switch Resource Usage parameters."""
 
+    fabric_name: str = Field(..., description="Fabric Name")
     pool_name: ResourcePool = Field(default=ResourcePool.ALL, description="Optional Resource Pool Name")
-    serial_number: str = Field(..., description="Switch Serial Number")
+    switch_name: str = Field(..., description="Switch Name")
 
 
 class RmSwitchResourceUsageConfigValidator(BaseModel):


### PR DESCRIPTION
# Commit Summary

This commit modifies the RmSwitchResourceUsage class to allow users to specify target switches using `switch_name` instead of requiring `serial_number`. The change includes internal translation from switch name to serial number using the `FabricInventory` class.

## User-facing changes to configuration files

1. Users should add two new mandatory parameters
  - fabric_name
  - switch_name

2. Users should remove previous mandatory parameter
  - serial_number

## Commit details

- Added `fabric_name` and `switch_name` fields to replace `serial_number` in user-facing configurations
- Implemented fabric inventory integration to translate switch names to serial numbers internally
- Updated validation logic to verify switch names exist within the specified fabric