### PR TITLE
## Commit Overview

### DIFF
--- a/lib/ndfc_python/validators/fabric_inventory.py
+++ b/lib/ndfc_python/validators/fabric_inventory.py
@@ -1,6 +1,4 @@
-from typing import List
-
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class FabricInventoryConfig(BaseModel):
@@ -10,7 +8,7 @@ class FabricInventoryConfig(BaseModel):
     Base validator for FabricInventory arguments
     """
 
-    fabric_name: str
+    fabric_name: str = Field(..., min_length=1, max_length=64, description="Name of the fabric")
 
 
 class FabricInventoryConfigValidator(BaseModel):
@@ -20,4 +18,4 @@ class FabricInventoryConfigValidator(BaseModel):
     config is a list of FabricInventoryConfig
     """
 
-    config: List[FabricInventoryConfig]
+    config: list[FabricInventoryConfig]


### PR DESCRIPTION
This commit refactors the fabric inventory functionality to use validator instances directly and modernizes the code structure. The changes improve code clarity by eliminating unnecessary JSON conversions and updating type annotations.

- Use validator instance directly instead of JSON serialization/deserialization
- Update type annotations from `typing.List` to built-in `list`
- Add field validation with Pydantic Field descriptor