### PR TITLE
Replace imported List with list

### DIFF
--- a/lib/ndfc_python/validators/bootflash_files_info.py
+++ b/lib/ndfc_python/validators/bootflash_files_info.py
@@ -1,6 +1,5 @@
 from enum import Enum
 from ipaddress import IPv4Address
-from typing import List
 
 from pydantic import BaseModel
 from typing_extensions import TypedDict
@@ -49,7 +48,6 @@ class Switch(TypedDict):
     """
 
     ip_address: IPv4Address
-    # targets: Optional[List[Target]] = []
 
 
 class BootflashFilesInfoConfig(BaseModel):
@@ -59,8 +57,8 @@ class BootflashFilesInfoConfig(BaseModel):
     Base validator for BootflashFilesInfo and ImagePolicyReplace arguments
     """
 
-    targets: List[Target]
-    switches: List[Switch]
+    targets: list[Target]
+    switches: list[Switch]
 
 
 class BootflashFilesInfoConfigValidator(BaseModel):

--- a/lib/ndfc_python/validators/config_deploy.py
+++ b/lib/ndfc_python/validators/config_deploy.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from pydantic import BaseModel, Field
 
 
@@ -20,4 +18,4 @@ class ConfigDeployConfigValidator(BaseModel):
     config is a list of ConfigDeployConfig
     """
 
-    config: List[ConfigDeployConfig]
+    config: list[ConfigDeployConfig]

--- a/lib/ndfc_python/validators/device_info.py
+++ b/lib/ndfc_python/validators/device_info.py
@@ -1,5 +1,4 @@
 from ipaddress import IPv4Address
-from typing import List
 
 from pydantic import BaseModel
 
@@ -21,4 +20,4 @@ class DeviceInfoConfigValidator(BaseModel):
     config is a list of DeviceInfoConfig
     """
 
-    config: List[DeviceInfoConfig]
+    config: list[DeviceInfoConfig]

--- a/lib/ndfc_python/validators/image_policy_create.py
+++ b/lib/ndfc_python/validators/image_policy_create.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import Optional
 
 from pydantic import BaseModel
 from typing_extensions import TypedDict
@@ -11,13 +11,13 @@ class ImagePolicyPackages(TypedDict):
     Dictionary containing the following keys
 
     - install
-        - List of packages to install
+        - list of packages to install
     - uninstall
-        - List of packages to uninstall
+        - list of packages to uninstall
     """
 
-    install: Optional[List[str]]
-    uninstall: Optional[List[str]]
+    install: Optional[list[str]]
+    uninstall: Optional[list[str]]
 
 
 class ImagePolicyCreateConfig(BaseModel):
@@ -44,4 +44,4 @@ class ImagePolicyCreateConfigValidator(BaseModel):
     config is a list of ImagePolicyCreateConfig
     """
 
-    config: List[ImagePolicyCreateConfig]
+    config: list[ImagePolicyCreateConfig]

--- a/lib/ndfc_python/validators/image_policy_delete.py
+++ b/lib/ndfc_python/validators/image_policy_delete.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from pydantic import BaseModel
 
 
@@ -20,4 +18,4 @@ class ImagePolicyDeleteConfigValidator(BaseModel):
     config is a list of ImagePolicyDeleteConfig
     """
 
-    config: List[ImagePolicyDeleteConfig]
+    config: list[ImagePolicyDeleteConfig]

--- a/lib/ndfc_python/validators/image_policy_info.py
+++ b/lib/ndfc_python/validators/image_policy_info.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from pydantic import BaseModel
 
 
@@ -20,4 +18,4 @@ class ImagePolicyInfoConfigValidator(BaseModel):
     config is a list of ImagePolicyInfoConfig
     """
 
-    config: List[ImagePolicyInfoConfig]
+    config: list[ImagePolicyInfoConfig]

--- a/lib/ndfc_python/validators/interface_access.py
+++ b/lib/ndfc_python/validators/interface_access.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import Optional
 
 from pydantic import BaseModel, Field, PositiveInt
 
@@ -33,4 +33,4 @@ class InterfaceAccessCreateConfigValidator(BaseModel):
     config is a list of InterfaceAccessCreateConfig
     """
 
-    config: List[InterfaceAccessCreateConfig]
+    config: list[InterfaceAccessCreateConfig]

--- a/lib/ndfc_python/validators/maintenance_mode.py
+++ b/lib/ndfc_python/validators/maintenance_mode.py
@@ -1,6 +1,6 @@
 from enum import Enum
 from ipaddress import IPv4Address
-from typing import List, Optional
+from typing import Optional
 
 from pydantic import BaseModel
 
@@ -45,7 +45,7 @@ class MaintenanceModeConfigValidator(BaseModel):
     config is a list of MaintenanceModeConfig
     """
 
-    config: List[MaintenanceModeConfig]
+    config: list[MaintenanceModeConfig]
 
 
 class MaintenanceModeInfoConfigValidator(BaseModel):
@@ -55,4 +55,4 @@ class MaintenanceModeInfoConfigValidator(BaseModel):
     config is a list of MaintenanceModeInfoConfig
     """
 
-    config: List[MaintenanceModeInfoConfig]
+    config: list[MaintenanceModeInfoConfig]

--- a/lib/ndfc_python/validators/network_create.py
+++ b/lib/ndfc_python/validators/network_create.py
@@ -1,5 +1,5 @@
 from ipaddress import IPv4Interface
-from typing import List, Optional
+from typing import Optional
 
 from pydantic import BaseModel, PositiveInt
 
@@ -28,4 +28,4 @@ class NetworkCreateConfigValidator(BaseModel):
     config is a list of NetworkCreateConfig
     """
 
-    config: List[NetworkCreateConfig]
+    config: list[NetworkCreateConfig]

--- a/lib/ndfc_python/validators/network_delete.py
+++ b/lib/ndfc_python/validators/network_delete.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from pydantic import BaseModel
 
 
@@ -21,4 +19,4 @@ class NetworkDeleteConfigValidator(BaseModel):
     config is a list of NetworkDeleteConfig
     """
 
-    config: List[NetworkDeleteConfig]
+    config: list[NetworkDeleteConfig]

--- a/lib/ndfc_python/validators/network_info.py
+++ b/lib/ndfc_python/validators/network_info.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from pydantic import BaseModel
 
 
@@ -21,4 +19,4 @@ class NetworkInfoConfigValidator(BaseModel):
     config is a list of NetworkInfoConfig
     """
 
-    config: List[NetworkInfoConfig]
+    config: list[NetworkInfoConfig]

--- a/lib/ndfc_python/validators/reachability.py
+++ b/lib/ndfc_python/validators/reachability.py
@@ -1,5 +1,4 @@
 from ipaddress import IPv4Address
-from typing import List
 
 from pydantic import BaseModel
 
@@ -22,4 +21,4 @@ class ReachabilityConfigValidator(BaseModel):
     config is a list of ReachabilityConfig
     """
 
-    config: List[ReachabilityConfig]
+    config: list[ReachabilityConfig]

--- a/lib/ndfc_python/validators/vrf_create.py
+++ b/lib/ndfc_python/validators/vrf_create.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from pydantic import BaseModel
 
 
@@ -24,4 +22,4 @@ class VrfCreateConfigValidator(BaseModel):
     config is a list of VrfCreateConfig
     """
 
-    config: List[VrfCreateConfig]
+    config: list[VrfCreateConfig]

--- a/lib/ndfc_python/validators/vrf_delete.py
+++ b/lib/ndfc_python/validators/vrf_delete.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from pydantic import BaseModel
 
 
@@ -11,7 +9,7 @@ class VrfDeleteConfig(BaseModel):
     """
 
     fabric_name: str
-    vrf_names: List[str]
+    vrf_names: list[str]
 
 
 class VrfDeleteConfigValidator(BaseModel):
@@ -21,4 +19,4 @@ class VrfDeleteConfigValidator(BaseModel):
     config is a list of VrfDeleteConfig
     """
 
-    config: List[VrfDeleteConfig]
+    config: list[VrfDeleteConfig]


### PR DESCRIPTION
Since we are using latest Python version, we no longer need to import List from typing.  This commit modifies all validators to use list rather than imported List.