### PR TITLE
NetworkCreate: Remove unneeded validation

### DIFF
--- a/lib/ndfc_python/network_create.py
+++ b/lib/ndfc_python/network_create.py
@@ -712,13 +712,6 @@ class NetworkCreate:
 
     @gateway_ip_address.setter
     def gateway_ip_address(self, value):
-        method_name = inspect.stack()[0][3]
-        try:
-            self.validations.verify_ipv4_address_with_prefix(value)
-        except AddressValueError as error:
-            msg = f"{self.class_name}.{method_name}: "
-            msg += f"Error detail: {error}"
-            raise ValueError(msg) from error
         self.template_config["gatewayIpAddress"] = value
 
     @property
@@ -734,13 +727,6 @@ class NetworkCreate:
 
     @gateway_ipv6_address.setter
     def gateway_ipv6_address(self, value):
-        method_name = inspect.stack()[0][3]
-        try:
-            self.validations.verify_ipv6_address_with_prefix(value)
-        except AddressValueError as error:
-            msg = f"{self.class_name}.{method_name}: "
-            msg += f"Error detail: {error}"
-            raise ValueError(msg) from error
         self.template_config["gatewayIpV6Address"] = value
 
     @property

--- a/lib/ndfc_python/network_create.py
+++ b/lib/ndfc_python/network_create.py
@@ -712,6 +712,8 @@ class NetworkCreate:
 
     @gateway_ip_address.setter
     def gateway_ip_address(self, value):
+        # It is assumed that value has already been validated
+        # in .lib/ndfc_python/validators/network_create.py
         self.template_config["gatewayIpAddress"] = value
 
     @property


### PR DESCRIPTION
1. lib/ndfc_python/network-create.py

Remove validation from the following properties:

- gateway_ip_address

This is already validated before being passed to NetworkCreate.  An argument could be made that removing the validation within NetworkCreate class ties the class to the example script, but we’re willing to live with this in exchange for simpler code.

- gateway_ipv6_address

The validation was incorrect, since a comma-separate list of ipv6 host addresses can be passed to this property.  Hence, we are removing the validation for now and will add it to the Pydantic validator for network_create later.