### PR TITLE
examples/network_*.py : Align with vrf_*.py

### DIFF
--- a/examples/network_attach.py
+++ b/examples/network_attach.py
@@ -54,21 +54,21 @@ from ndfc_python.parsers.parser_nd_ip4 import parser_nd_ip4
 from ndfc_python.parsers.parser_nd_password import parser_nd_password
 from ndfc_python.parsers.parser_nd_username import parser_nd_username
 from ndfc_python.read_config import ReadConfig
-from ndfc_python.validators.network_attach import NetworkAttachConfigValidator
+from ndfc_python.validators.network_attach import NetworkAttachConfig, NetworkAttachConfigValidator
 from plugins.module_utils.common.response_handler import ResponseHandler
 from plugins.module_utils.common.rest_send_v2 import RestSend
 from plugins.module_utils.common.results import Results
 from pydantic import ValidationError
 
 
-def network_attach(cfg: dict) -> None:
+def action(cfg: NetworkAttachConfig) -> None:
     """
     Given a network-attach configuration, attach the network.
     """
     # Prepopulate error message in case of failure
-    fabric_name = cfg.get("fabric")
-    network_name = cfg.get("networkName")
-    switch_name = cfg.get("switch_name")
+    fabric_name = cfg.fabric
+    network_name = cfg.networkName
+    switch_name = cfg.switch_name
     errmsg = f"Error attaching fabric {fabric_name}, "
     errmsg += f"network {network_name}, "
     errmsg += f"to switch_name {switch_name}. "
@@ -76,19 +76,19 @@ def network_attach(cfg: dict) -> None:
         instance = NetworkAttach()
         instance.rest_send = rest_send
         instance.results = Results()
-        instance.detach_switch_ports = cfg.get("detachSwitchPorts", [])
-        instance.dot1q_vlan = cfg.get("dot1qVlan")
-        instance.extension_values = cfg.get("extensionValues", "")
+        instance.detach_switch_ports = cfg.detachSwitchPorts
+        instance.dot1q_vlan = cfg.dot1QVlan
+        instance.extension_values = cfg.extensionValues
         instance.fabric_name = fabric_name
-        instance.freeform_config = cfg.get("freeformConfig", [])
-        instance.instance_values = cfg.get("instanceValues", "")
+        instance.freeform_config = cfg.freeformConfig
+        instance.instance_values = cfg.instanceValues
         instance.network_name = network_name
-        instance.peer_switch_name = cfg.get("peer_switch_name", "")
+        instance.peer_switch_name = cfg.peer_switch_name
         instance.switch_name = switch_name
-        instance.switch_ports = cfg.get("switchPorts", [])
-        instance.tor_ports = cfg.get("torPorts", [])
-        instance.untagged = cfg.get("untagged", False)
-        instance.vlan = cfg.get("vlan")
+        instance.switch_ports = cfg.switchPorts
+        instance.tor_ports = cfg.torPorts
+        instance.untagged = cfg.untagged
+        instance.vlan = cfg.vlan
         instance.commit()
         data = instance.rest_send.response_current.get("DATA", {})
     except ValueError as error:
@@ -179,7 +179,5 @@ rest_send.response_handler = ResponseHandler()
 rest_send.timeout = 2
 rest_send.send_interval = 5
 
-params_list = json.loads(validator.model_dump_json()).get("config", {})
-
-for params in params_list:
-    network_attach(params)
+for item in validator.config:
+    action(item)

--- a/examples/network_attach.py
+++ b/examples/network_attach.py
@@ -39,7 +39,6 @@ export NDFC_LOGGING_CONFIG=$HOME/repos/ndfc-python/lib/ndfc_python/logging_confi
 """
 # pylint: disable=duplicate-code
 import argparse
-import json
 import logging
 import sys
 

--- a/examples/network_info.py
+++ b/examples/network_info.py
@@ -54,20 +54,20 @@ from ndfc_python.parsers.parser_nd_ip4 import parser_nd_ip4
 from ndfc_python.parsers.parser_nd_password import parser_nd_password
 from ndfc_python.parsers.parser_nd_username import parser_nd_username
 from ndfc_python.read_config import ReadConfig
-from ndfc_python.validators.network_info import NetworkInfoConfigValidator
+from ndfc_python.validators.network_info import NetworkInfoConfig, NetworkInfoConfigValidator
 from plugins.module_utils.common.response_handler import ResponseHandler
 from plugins.module_utils.common.rest_send_v2 import RestSend
 from plugins.module_utils.common.results import Results
 from pydantic import ValidationError
 
 
-def network_info(cfg: dict) -> None:
+def action(cfg: NetworkInfoConfig) -> None:
     """
     Given a network configuration, retrieve information for the specified network.
     """
     # Prepopulate error message
-    fabric_name = cfg.get("fabric_name")
-    network_name = cfg.get("network_name")
+    fabric_name = cfg.fabric_name
+    network_name = cfg.network_name
     errmsg = "Error retrieving network information for "
     errmsg += f"fabric_name {fabric_name} "
     errmsg += f"network_name {network_name}. "
@@ -164,7 +164,5 @@ rest_send.response_handler = ResponseHandler()
 rest_send.timeout = 2
 rest_send.send_interval = 5
 
-params_list = json.loads(validator.model_dump_json()).get("config", {})
-
-for params in params_list:
-    network_info(params)
+for item in validator.config:
+    action(item)


### PR DESCRIPTION
Align example network scripts with recent changes to the example vrf scripts.  Specifically:

1. rename main worker function to `action`

2. Remove unneeded serializationdeserialization, but using validator directly.

3. In network_create.py, remove the enable_ir property since it was not relevant.