### PR TITLE
interface_access_create: Standardize validator use

### DIFF
--- a/examples/interface_access_create.py
+++ b/examples/interface_access_create.py
@@ -62,7 +62,7 @@ from pydantic import ValidationError
 
 def action(cfg: InterfaceAccessCreateConfig) -> None:
     """
-    Given a network configuration, create the network.
+    Given an interface configuration, create the access-mode interface.
     """
     try:
         instance = InterfaceAccessCreate()


### PR DESCRIPTION
## Pull Request Overview

This commit aligns the interface_access_create.py example script with recent changes made to VRF and network example scripts by standardizing the function naming and data handling patterns.

- Rename main worker function from `network_*` to `action` across all network example scripts
- Replace JSON serialization/deserialization with direct validator usage
- Update function parameters to use typed Pydantic models instead of raw dictionaries