### PR TITLE
DeviceInfo: minor refactor to example script

### DIFF
--- a/examples/device_info.py
+++ b/examples/device_info.py
@@ -58,7 +58,7 @@ from pydantic import ValidationError
 
 def get_fabric_inventory(fabric_name: str, restsend: RestSend, results: Results) -> FabricInventory:
     """
-    Given a fabric name, return the fabric inventory as a dictionary.
+    Given fabric_name, return a FabricInventory instance for fabric_name.
 
     Args:
         fabric_name (str): fabric name
@@ -66,7 +66,7 @@ def get_fabric_inventory(fabric_name: str, restsend: RestSend, results: Results)
         results (Results): results object
 
     Returns:
-        dict: fabric inventory
+        FabricInventory: fabric inventory instance
     """
     fabric_inventory = FabricInventory()
     fabric_inventory.fabric_name = fabric_name


### PR DESCRIPTION
1. get_fabric_inventory

Return the instance rather than a dictionary

2. action

2a. Leverage FabricInventory.devices, rather than the dictionary keys

2b. Leverage FabricInventory.switch_name_to_ipv4_address rather than accessing the inventory dictionary