### PR TITLE
NetworkCreate, NetworkDelete enhancements

### DIFF
--- a/lib/ndfc_python/network_delete.py
+++ b/lib/ndfc_python/network_delete.py
@@ -79,7 +79,7 @@ class NetworkDelete:
             msg += "does not exist on the controller."
             raise ValueError(msg)
 
-        if self.ok_to_delete_network() is False:
+        if not self.ok_to_delete_network():
             msg = f"{self.class_name}.{method_name}: "
             msg += f"network_name {self.network_name} "
             msg += f"either does not exist in fabric {self.fabric_name}, "


### PR DESCRIPTION
Summary

1. Introduces a new method `fabric_exists` to verify whether a fabric exists on the controller.

2. Removes FabricDetailsByName import

`fabric_exists` uses a more efficient controller endpoint to return this information.

3. NetworkDelete. network_name_exists_in_fabric

- Rrename method to `ok_to_delete_network`
- Implement an additional check to verify that networkStatus is not equal to DEPLOYED (the controller returns an error in response to DELETE request if the target network state is DEPLOYED).