### PR TITLE
Network*: leverage new Properties class

### DIFF
--- a/lib/ndfc_python/network_attach.py
+++ b/lib/ndfc_python/network_attach.py
@@ -44,12 +44,10 @@ import inspect
 import logging
 
 from ndfc_python.common.fabric.fabric_inventory import FabricInventory
+from ndfc_python.common.properties import Properties
 from ndfc_python.validations import Validations
-from plugins.module_utils.common.properties import Properties
 
 
-@Properties.add_rest_send
-@Properties.add_results
 class NetworkAttach:
     """
     # Summary
@@ -67,10 +65,15 @@ class NetworkAttach:
         self.class_name = __class__.__name__
         self.log = logging.getLogger(f"ndfc_python.{self.class_name}")
 
+        self.properties = Properties()
+        self.rest_send = self.properties.rest_send
+        self.results = self.properties.results
+
+        self.validations = Validations()
+
         self.api_v1 = "/appcenter/cisco/ndfc/api/v1"
         self.ep_fabrics = f"{self.api_v1}/lan-fabric/rest/top-down/fabrics"
         self.fabric_inventory = FabricInventory()
-        self.validations = Validations()
 
         self._detach_switch_ports = ""
         self._dot1q_vlan = ""
@@ -108,7 +111,6 @@ class NetworkAttach:
         final verification of all parameters
         """
         method_name = inspect.stack()[0][3]
-        # pylint: disable=no-member
         if self.rest_send is None:
             msg = f"{self.class_name}.{method_name}: "
             msg += f"{self.class_name}.rest_send must be set before calling "
@@ -120,7 +122,6 @@ class NetworkAttach:
             msg += f"{self.class_name}.results must be set before calling "
             msg += f"{self.class_name}.commit"
             raise ValueError(msg)
-        # pylint: enable=no-member
 
         if not self.fabric_name:
             msg = f"{self.class_name}.{method_name}: "
@@ -186,7 +187,6 @@ class NetworkAttach:
         path += f"/{self.fabric_name}/networks"
         verb = "GET"
 
-        # pylint: disable=no-member
         try:
             self.rest_send.path = path
             self.rest_send.verb = verb
@@ -215,21 +215,19 @@ class NetworkAttach:
 
         """
         method_name = inspect.stack()[0][3]
-        # pylint: disable=no-member
         try:
             self.fabric_inventory.fabric_name = self.fabric_name
-            self.fabric_inventory.rest_send = self.rest_send  # type: ignore[attr-defined]
-            self.fabric_inventory.results = self.results  # type: ignore[attr-defined]
+            self.fabric_inventory.rest_send = self.rest_send
+            self.fabric_inventory.results = self.results
             self.fabric_inventory.commit()
         except ValueError as error:
             msg = f"{self.class_name}.{method_name}: "
             msg += f"Unable to populate fabric inventory for fabric {self.fabric_name}. "
-            if self.fabric_inventory.return_code == 404:  # type: ignore[attr-defined]
+            if self.fabric_inventory.return_code == 404:
                 msg += f"fabric_name {self.fabric_name} does not exist on the controller. "
             else:
                 msg += f"Error details: {error}"
             raise ValueError(msg) from error
-        # pylint: enable=no-member
         self._fabric_inventory_populated = True
 
     def _build_lan_attach_list_item(self, switch_name: str) -> dict:
@@ -279,10 +277,9 @@ class NetworkAttach:
         Attach a network to a switch
         """
         method_name = inspect.stack()[0][3]
-        # pylint: disable=no-member
         self.fabric_inventory.fabric_name = self.fabric_name
-        self.fabric_inventory.rest_send = self.rest_send  # type: ignore[attr-defined]
-        self.fabric_inventory.results = self.results  # type: ignore[attr-defined]
+        self.fabric_inventory.rest_send = self.rest_send
+        self.fabric_inventory.results = self.results
         self.fabric_inventory.commit()
 
         self._final_verification()

--- a/lib/ndfc_python/network_create.py
+++ b/lib/ndfc_python/network_create.py
@@ -66,12 +66,10 @@ import json
 import logging
 from ipaddress import AddressValueError, IPv4Interface
 
+from ndfc_python.common.properties import Properties
 from ndfc_python.validations import Validations
-from plugins.module_utils.common.properties import Properties
 
 
-@Properties.add_rest_send
-@Properties.add_results
 class NetworkCreate:
     """
     # Summary
@@ -88,6 +86,10 @@ class NetworkCreate:
     def __init__(self):
         self.class_name = __class__.__name__
         self.log = logging.getLogger(f"ndfc_python.{self.class_name}")
+
+        self.properties = Properties()
+        self.rest_send = self.properties.rest_send
+        self.results = self.properties.results
 
         self.validations = Validations()
 
@@ -350,7 +352,6 @@ class NetworkCreate:
         final verification of all parameters
         """
         method_name = inspect.stack()[0][3]
-        # pylint: disable=no-member
         if self.rest_send is None:
             msg = f"{self.class_name}.{method_name}: "
             msg += f"{self.class_name}.rest_send must be set before calling "
@@ -362,7 +363,6 @@ class NetworkCreate:
             msg += f"{self.class_name}.results must be set before calling "
             msg += f"{self.class_name}.commit"
             raise ValueError(msg)
-        # pylint: enable=no-member
 
         for param in self._payload_set_mandatory:
             if self.payload.get(param) == "" or self.payload.get(param) is None:
@@ -409,21 +409,19 @@ class NetworkCreate:
         path = "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/msd/fabric-associations"
         verb = "GET"
 
-        # pylint: disable=no-member
         try:
-            self.rest_send.path = path  # type: ignore[attr-defined]
-            self.rest_send.verb = verb  # type: ignore[attr-defined]
-            self.rest_send.commit()  # type: ignore[attr-defined]
+            self.rest_send.path = path
+            self.rest_send.verb = verb
+            self.rest_send.commit()
         except (TypeError, ValueError) as error:
             msg = f"{self.class_name}.{method_name}: "
             msg += f"Unable to send {verb} request to the controller. "
             msg += f"Error details: {error}"
             raise ValueError(msg) from error
 
-        for item in self.rest_send.response_current["DATA"]:  # type: ignore[attr-defined]
+        for item in self.rest_send.response_current["DATA"]:
             if item.get("fabricName") == self.fabric_name:
                 return True
-        # pylint: enable=no-member
         return False
 
     def vrf_exists_in_fabric(self):
@@ -437,7 +435,6 @@ class NetworkCreate:
         path += f"/{self.fabric_name}/vrfs"
         verb = "GET"
 
-        # pylint: disable=no-member
         try:
             self.rest_send.path = path
             self.rest_send.verb = verb
@@ -458,7 +455,6 @@ class NetworkCreate:
             if item_d["vrfName"] != self.vrf_name:
                 continue
             return True
-        # pylint: enable=no-member
         return False
 
     def network_id_exists_in_fabric(self):
@@ -471,7 +467,6 @@ class NetworkCreate:
         path = "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/top-down/fabrics"
         path += f"/{self.fabric_name}/networks"
         verb = "GET"
-        # pylint: disable=no-member
         try:
             self.rest_send.path = path
             self.rest_send.verb = verb
@@ -500,7 +495,6 @@ class NetworkCreate:
         path += f"/{self.fabric_name}/networks"
         verb = "GET"
 
-        # pylint: disable=no-member
         try:
             self.rest_send.path = path
             self.rest_send.verb = verb
@@ -531,7 +525,6 @@ class NetworkCreate:
         verb = "POST"
 
         self.payload["networkTemplateConfig"] = json.dumps(self.template_config)
-        # pylint: disable=no-member
         try:
             self.rest_send.path = path
             self.rest_send.verb = verb


### PR DESCRIPTION
This commit follows on the previous commit to leverage the new Properties class for the remaining Network classes:

- NetworkAttach
- NetworkCreate
- NetworkDetach
- NetworkInfo

1. Remove now-unneeded linter suppression directives

2. import/instantiate Properties.rest_send and Properties.results

3. Remove import for DCNM Ansible collection Properties

4. NetworkDetach: Remove properties dict and replace with individual property instantiations