### PR TITLE
VrfDetach: Fix VrfDetachConfig validator

### DIFF
--- a/lib/ndfc_python/validators/vrf_detach.py
+++ b/lib/ndfc_python/validators/vrf_detach.py
@@ -6,9 +6,9 @@ class VrfDetachConfig(BaseModel):
 
     deployment: StrictBool = Field(default=True)
 
-    fabric: str = Field(..., alias="fabric_name")
+    fabric_name: str
     switch_name: str
-    vrfName: str = Field(..., alias="vrf_name")
+    vrf_name: str
 
 
 class VrfDetachConfigValidator(BaseModel):


### PR DESCRIPTION
This validator was somehow missed when standardizing on fabric_name, switch_name, and vrf_name configuration options.

This commit rectifies this oversight.