### PR TITLE
Config*: Leverage FabricsInfo, general cleanup

### DIFF
--- a/lib/ndfc_python/config_deploy.py
+++ b/lib/ndfc_python/config_deploy.py
@@ -65,15 +65,21 @@ class ConfigDeploy:
         """
         Initialize the REST payload
         """
-        self.payload = {}
+        self.payload: dict = {}
 
     def _final_verification(self) -> None:
         """
         Any final verification steps before sending the request
         """
+        method_name = inspect.stack()[0][3]
         if self.fabric_name is None:
-            msg = f"{self.class_name}._final_verification: "
+            msg = f"{self.class_name}.{method_name}: "
             msg += "fabric_name must be set before calling commit()."
+            raise ValueError(msg)
+
+        if self.rest_send is None:
+            msg = f"{self.class_name}.{method_name}: "
+            msg += "rest_send must be set before calling commit()."
             raise ValueError(msg)
 
     def fabric_exists(self) -> bool:

--- a/lib/ndfc_python/config_save.py
+++ b/lib/ndfc_python/config_save.py
@@ -67,15 +67,21 @@ class ConfigSave:
         """
         Initialize the REST payload
         """
-        self.payload = {}
+        self.payload: dict = {}
 
     def _final_verification(self) -> None:
         """
         Any final verification steps before sending the request
         """
+        method_name = inspect.stack()[0][3]
         if not self.fabric_name:
-            msg = f"{self.class_name}._final_verification: "
+            msg = f"{self.class_name}.{method_name}: "
             msg += "fabric_name must be set before calling commit()."
+            raise ValueError(msg)
+
+        if self.rest_send is None:
+            msg = f"{self.class_name}.{method_name}: "
+            msg += "rest_send must be set before calling commit()."
             raise ValueError(msg)
 
     def fabric_exists(self) -> bool:

--- a/lib/ndfc_python/config_save.py
+++ b/lib/ndfc_python/config_save.py
@@ -25,15 +25,13 @@ No JSON payload is required for this request.
 import inspect
 import logging
 
+from ndfc_python.common.fabric.fabrics_info import FabricsInfo
+from ndfc_python.common.properties import Properties
 from ndfc_python.validations import Validations
 from plugins.module_utils.common.api.v1.lan_fabric.rest.control.fabrics.fabrics import EpFabrics
 from plugins.module_utils.common.conversion import ConversionUtils
-from plugins.module_utils.common.properties import Properties
-from plugins.module_utils.fabric.fabric_details_v2 import FabricDetailsByName
 
 
-@Properties.add_rest_send
-@Properties.add_results
 class ConfigSave:
     """
     # Summary
@@ -53,46 +51,44 @@ class ConfigSave:
         self.log = logging.getLogger(f"ndfc_python.{self.class_name}")
 
         self.conversion = ConversionUtils()
-        self.validations = Validations()
         self.ep_rest_control_fabrics = EpFabrics()
+        self.fabrics_info = FabricsInfo()
+        self.properties = Properties()
+        self.validations = Validations()
 
-        self._fabric_name = None
+        self.rest_send = self.properties.rest_send
+
+        self._fabric_name = ""
         self._response_data = None
 
         self._init_payload()
 
-    def _init_payload(self):
+    def _init_payload(self) -> None:
         """
         Initialize the REST payload
         """
         self.payload = {}
 
-    def _final_verification(self):
+    def _final_verification(self) -> None:
         """
         Any final verification steps before sending the request
         """
-        if self.fabric_name is None:
+        if not self.fabric_name:
             msg = f"{self.class_name}._final_verification: "
             msg += "fabric_name must be set before calling commit()."
             raise ValueError(msg)
 
-    def fabric_exists(self):
+    def fabric_exists(self) -> bool:
         """
         Return True if self.fabric_name exists on the controller.
         Return False otherwise.
         """
-        instance = FabricDetailsByName()
-        # pylint: disable=no-member
-        instance.rest_send = self.rest_send
-        instance.results = self.results
-        # pylint: enable=no-member
-        instance.refresh()
-        instance.filter = self.fabric_name
-        if instance.filtered_data is None:
-            return False
-        return True
+        self.fabrics_info.rest_send = self.rest_send
+        self.fabrics_info.commit()
+        self.fabrics_info.filter = self.fabric_name
+        return self.fabrics_info.fabric_exists
 
-    def commit(self):
+    def commit(self) -> None:
         """
         Send a POST request to the controller to the config-save endpoint
         """
@@ -150,14 +146,14 @@ class ConfigSave:
         return self.response_data.get(item)
 
     @property
-    def fabric_name(self):
+    def fabric_name(self) -> str:
         """
-        Return the current fabric name.
+        Set (setter) or return (getter) the current fabric name.
         """
         return self._fabric_name
 
     @fabric_name.setter
-    def fabric_name(self, param):
+    def fabric_name(self, param: str) -> None:
         self._fabric_name = param
 
     @property

--- a/lib/ndfc_python/config_save.py
+++ b/lib/ndfc_python/config_save.py
@@ -76,7 +76,7 @@ class ConfigSave:
         method_name = inspect.stack()[0][3]
         if not self.fabric_name:
             msg = f"{self.class_name}.{method_name}: "
-            msg += "fabric_name must be set before calling commit()."
+            msg += "fabric_name must be set to a non-empty string before calling commit()."
             raise ValueError(msg)
 
         if self.rest_send is None:


### PR DESCRIPTION
Summary

1. Modifies ConfigDeploy and ConfigSave classes to leverage FabricsInfo.fabric_exists

2. Replaces DCNM Ansible Collection Properties class with local Properties class that injects the rest_send property via instantiation rather than class decorator.

3. Adds type hints to most method signatures.

4. Removes linter suppression directives as these are no longeer needed.

NOTES:

1. We do not need the Properties.results property.  Hence, we are not replacing @Properties.add_results with Properties.results.

2. Properties.rest_send is intentionally set to None in the Properties class.  It is up to the user to set this property to a RestSend instance.  This is clearly documented in the example scripts for ConfigDeploy and ConfigSave.

3. The changes to these classes are backward compatible with existing example scripts.