### PR TITLE
Network*: Leverage FabricInfo

### DIFF
--- a/lib/ndfc_python/network_attach.py
+++ b/lib/ndfc_python/network_attach.py
@@ -39,6 +39,7 @@ Send network attach POST requests to the controller
 
 # We are using isort for import sorting.
 # pylint: disable=wrong-import-order
+# pylint: disable=too-many-branches
 
 import inspect
 import logging

--- a/lib/ndfc_python/network_attach.py
+++ b/lib/ndfc_python/network_attach.py
@@ -43,8 +43,8 @@ Send network attach POST requests to the controller
 import inspect
 import logging
 
-from ndfc_python.common.fabric.fabrics_info import FabricsInfo
 from ndfc_python.common.fabric.fabric_inventory import FabricInventory
+from ndfc_python.common.fabric.fabrics_info import FabricsInfo
 from ndfc_python.common.properties import Properties
 from ndfc_python.validations import Validations
 

--- a/lib/ndfc_python/network_create.py
+++ b/lib/ndfc_python/network_create.py
@@ -66,6 +66,7 @@ import json
 import logging
 from ipaddress import AddressValueError, IPv4Interface
 
+from ndfc_python.common.fabric.fabrics_info import FabricsInfo
 from ndfc_python.common.properties import Properties
 from ndfc_python.validations import Validations
 
@@ -87,14 +88,11 @@ class NetworkCreate:
         self.class_name = __class__.__name__
         self.log = logging.getLogger(f"ndfc_python.{self.class_name}")
 
+        self.fabrics_info = FabricsInfo()
         self.properties = Properties()
-        self.rest_send = self.properties.rest_send
-        self.results = self.properties.results
-
         self.validations = Validations()
 
-        self._rest_send = None
-        self._results = None
+        self.rest_send = self.properties.rest_send
 
         self._payload_set = set()
         self._payload_set_mandatory = set()
@@ -358,12 +356,6 @@ class NetworkCreate:
             msg += f"{self.class_name}.commit"
             raise ValueError(msg)
 
-        if self.results is None:
-            msg = f"{self.class_name}.{method_name}: "
-            msg += f"{self.class_name}.results must be set before calling "
-            msg += f"{self.class_name}.commit"
-            raise ValueError(msg)
-
         for param in self._payload_set_mandatory:
             if self.payload.get(param) == "" or self.payload.get(param) is None:
                 msg = f"{self.class_name}.{method_name}: "
@@ -371,14 +363,13 @@ class NetworkCreate:
                 msg += f"{self._map_payload_param(param)} "
                 msg += f"before calling {self.class_name}.commit"
                 raise ValueError(msg)
-        # fmt: off
+
         for param in self._template_config_set_mandatory:
             if self.template_config[param] == "":
                 msg = f"{self.class_name}.{method_name}: "
                 msg += f"Call {self.class_name}.{self._map_template_config_param(param)} "
                 msg += f"before calling {self.class_name}.commit"
                 raise ValueError(msg)
-        # fmt: on
 
         if not self.fabric_exists():
             msg = f"{self.class_name}.{method_name}: "
@@ -405,24 +396,10 @@ class NetworkCreate:
         Return True if self.fabric_name exists on the controller.
         Return False otherwise.
         """
-        method_name = inspect.stack()[0][3]
-        path = "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/fabrics/msd/fabric-associations"
-        verb = "GET"
-
-        try:
-            self.rest_send.path = path
-            self.rest_send.verb = verb
-            self.rest_send.commit()
-        except (TypeError, ValueError) as error:
-            msg = f"{self.class_name}.{method_name}: "
-            msg += f"Unable to send {verb} request to the controller. "
-            msg += f"Error details: {error}"
-            raise ValueError(msg) from error
-
-        for item in self.rest_send.response_current["DATA"]:
-            if item.get("fabricName") == self.fabric_name:
-                return True
-        return False
+        self.fabrics_info.rest_send = self.rest_send
+        self.fabrics_info.commit()
+        self.fabrics_info.filter = self.fabric_name
+        return self.fabrics_info.fabric_exists
 
     def vrf_exists_in_fabric(self):
         """

--- a/lib/ndfc_python/network_detach.py
+++ b/lib/ndfc_python/network_detach.py
@@ -37,9 +37,9 @@ import inspect
 import logging
 
 from ndfc_python.common.fabric.fabric_inventory import FabricInventory
+from ndfc_python.common.fabric.fabrics_info import FabricsInfo
 from ndfc_python.common.properties import Properties
 from ndfc_python.validations import Validations
-from plugins.module_utils.fabric.fabric_details_v2 import FabricDetailsByName
 
 
 class NetworkDetach:
@@ -59,6 +59,7 @@ class NetworkDetach:
         self.class_name = __class__.__name__
         self.log = logging.getLogger(f"ndfc_python.{self.class_name}")
 
+        self.fabrics_info = FabricsInfo()
         self.properties = Properties()
         self.rest_send = self.properties.rest_send
         self.results = self.properties.results
@@ -136,19 +137,15 @@ class NetworkDetach:
                 msg += "are not vPC peer switches."
                 raise ValueError(msg)
 
-    def fabric_exists(self):
+    def fabric_exists(self) -> bool:
         """
         Return True if self.fabric_name exists on the controller.
         Return False otherwise.
         """
-        instance = FabricDetailsByName()
-        instance.rest_send = self.rest_send
-        instance.results = self.results
-        instance.refresh()
-        instance.filter = self.fabric_name
-        if instance.filtered_data is None:
-            return False
-        return True
+        self.fabrics_info.rest_send = self.rest_send
+        self.fabrics_info.commit()
+        self.fabrics_info.filter = self.fabric_name
+        return self.fabrics_info.fabric_exists
 
     def network_name_exists_in_fabric(self):
         """
@@ -213,7 +210,7 @@ class NetworkDetach:
         _payload.append(_payload_item)
         return _payload
 
-    def commit(self):
+    def commit(self) -> None:
         """
         Detach a network from a switch
         """
@@ -244,9 +241,9 @@ class NetworkDetach:
     @property
     def detach_switch_ports(self) -> str:
         """
-        return the current value of detachSwitchPorts
+        Set (setter) or return (getter) the current value of detach_switch_ports
 
-        detachSwitchPorts is converted from a list to a comma-separated string in the setter.
+        detach_switch_ports is converted from a list to a comma-separated string in the setter.
         """
         return self._detach_switch_ports
 
@@ -257,7 +254,7 @@ class NetworkDetach:
     @property
     def fabric_name(self) -> str:
         """
-        return the current value of fabric
+        Set (setter) or return (getter) the current value of fabric_name
         """
         return self._fabric_name
 
@@ -268,7 +265,7 @@ class NetworkDetach:
     @property
     def network_name(self) -> str:
         """
-        return the current value of networkName
+        Set (setter) or return (getter) the current value of network_name
         """
         return self._network_name
 
@@ -279,7 +276,7 @@ class NetworkDetach:
     @property
     def peer_switch_name(self) -> str:
         """
-        return the current value of peer_switch_name
+        Set (setter) or return (getter) the current value of peer_switch_name
         """
         return self._peer_switch_name
 
@@ -290,7 +287,7 @@ class NetworkDetach:
     @property
     def switch_name(self) -> str:
         """
-        return the current value of switch_name
+        Set (setter) or return (getter) the current value of switch_name
         """
         return self._switch_name
 
@@ -301,7 +298,7 @@ class NetworkDetach:
     @property
     def vlan(self) -> str:
         """
-        return the current value of vlan
+        Set (setter) or return (getter) the current value of vlan
         """
         return self._vlan
 

--- a/lib/ndfc_python/network_info.py
+++ b/lib/ndfc_python/network_info.py
@@ -20,9 +20,9 @@ Path: /appcenter/cisco/ndfc/api/v1/lan-fabric/rest/top-down/fabrics/{{fabric_nam
 import inspect
 import logging
 
+from ndfc_python.common.fabric.fabrics_info import FabricsInfo
 from ndfc_python.common.properties import Properties
 from ndfc_python.validations import Validations
-from plugins.module_utils.fabric.fabric_details_v2 import FabricDetailsByName
 
 
 class NetworkInfoEndpoint:
@@ -37,13 +37,13 @@ class NetworkInfoEndpoint:
         self.apiv1 = "/appcenter/cisco/ndfc/api/v1"
         self.ep_fabrics = f"{self.apiv1}/lan-fabric/rest/top-down/fabrics"
 
-        self._endpoint = ""
+        self._path = ""
         self._fabric_name = ""
         self._network_name = ""
 
         self.verb = "GET"
 
-    def _final_verification(self):
+    def _final_verification(self) -> None:
         """
         final verification of all parameters
         """
@@ -64,18 +64,18 @@ class NetworkInfoEndpoint:
         """
         Build and return the endpoint for the API request
         """
-        self.endpoint = f"{self.ep_fabrics}/{self.fabric_name}/networks/{self.network_name}"
+        self.path = f"{self.ep_fabrics}/{self.fabric_name}/networks/{self.network_name}"
 
     @property
-    def endpoint(self) -> str:
+    def path(self) -> str:
         """
-        return the current value of endpoint
+        Set (setter) or return (getter) the current value of the endpoint path
         """
-        return self._endpoint
+        return self._path
 
-    @endpoint.setter
-    def endpoint(self, value: str) -> None:
-        self._endpoint = value
+    @path.setter
+    def path(self, value: str) -> None:
+        self._path = value
 
     @property
     def fabric_name(self) -> str:
@@ -117,18 +117,17 @@ class NetworkInfo:
         self.class_name = __class__.__name__
         self.log = logging.getLogger(f"ndfc_python.{self.class_name}")
 
+        self.fabrics_info = FabricsInfo()
         self.endpoint = NetworkInfoEndpoint()
-
         self.properties = Properties()
-        self.rest_send = self.properties.rest_send
-        self.results = self.properties.results
-
         self.validations = Validations()
+
+        self.rest_send = self.properties.rest_send
 
         self._fabric_name = ""
         self._network_name = ""
 
-    def _final_verification(self):
+    def _final_verification(self) -> None:
         """
         final verification of all parameters
         """
@@ -136,11 +135,6 @@ class NetworkInfo:
         if self.rest_send is None:
             msg = f"{self.class_name}.{method_name}: "
             msg += f"{self.class_name}.rest_send must be set before calling "
-            msg += f"{self.class_name}.commit"
-            raise ValueError(msg)
-        if self.results is None:
-            msg = f"{self.class_name}.{method_name}: "
-            msg += f"{self.class_name}.results must be set before calling "
             msg += f"{self.class_name}.commit"
             raise ValueError(msg)
 
@@ -156,21 +150,17 @@ class NetworkInfo:
             msg += f"in fabric {self.fabric_name}."
             raise ValueError(msg)
 
-    def fabric_exists(self):
+    def fabric_exists(self) -> bool:
         """
         Return True if self.fabric_name exists on the controller.
         Return False otherwise.
         """
-        instance = FabricDetailsByName()
-        instance.rest_send = self.rest_send
-        instance.results = self.results
-        instance.refresh()
-        instance.filter = self.fabric_name
-        if instance.filtered_data is None:
-            return False
-        return True
+        self.fabrics_info.rest_send = self.rest_send
+        self.fabrics_info.commit()
+        self.fabrics_info.filter = self.fabric_name
+        return self.fabrics_info.fabric_exists
 
-    def network_name_exists_in_fabric(self):
+    def network_name_exists_in_fabric(self) -> bool:
         """
         Return True if networkName exists in the fabric.
         Else return False
@@ -197,7 +187,7 @@ class NetworkInfo:
                 return True
         return False
 
-    def commit(self):
+    def commit(self) -> None:
         """
         Retrieve network information from the controller.
         """
@@ -207,7 +197,7 @@ class NetworkInfo:
         self.endpoint.fabric_name = self.fabric_name
         self.endpoint.network_name = self.network_name
         self.endpoint.commit()
-        path = self.endpoint.endpoint
+        path = self.endpoint.path
         verb = self.endpoint.verb
 
         try:
@@ -223,7 +213,7 @@ class NetworkInfo:
     @property
     def fabric_name(self) -> str:
         """
-        return the current value of fabric_name
+        Set (setter) or return (getter) the current value of fabric_name
         """
         return self._fabric_name
 
@@ -234,7 +224,7 @@ class NetworkInfo:
     @property
     def network_name(self) -> str:
         """
-        return the current value of networkName
+        Set (setter) or return (getter) the current value of network_name
         """
         return self._network_name
 


### PR DESCRIPTION
1. Leverage FabricInfo to determine if fabric_name exists on the controller in the following classes:

- NetworkAttach
- NetworkCreate
- NetworkDelete
- NetworkDetach
- NetworkInfo

2. For all of the above classes, add type hints to method signatures if not already present.

3. For all the above classes, remove the requirement that Results be set if it is not required.