### PR TITLE
Policy create

### DIFF
--- a/examples/config/policy_create.yaml
+++ b/examples/config/policy_create.yaml
@@ -1,0 +1,14 @@
+---
+config:
+  - switch_name: LE3
+    fabric_name: SITE3 # fabric_name needed to retrieve switch information
+    description: management vrf static route to syslog server
+    entity_name: SWITCH
+    entity_type: SWITCH
+    priority: 200
+    source: ""
+    template_name: vrf_static_route
+    nv_pairs:
+      IP_PREFIX: 192.168.7.1/32
+      NEXT_HOP_IP: 192.168.12.1
+      VRF_NAME: management

--- a/examples/config/s34/policy_create.yaml
+++ b/examples/config/s34/policy_create.yaml
@@ -1,0 +1,14 @@
+---
+config:
+  - switch_name: LE3
+    fabric_name: SITE3 # fabric_name needed to retrieve switch information
+    description: management vrf static route to syslog server
+    entity_name: SWITCH
+    entity_type: SWITCH
+    priority: 200
+    source: ""
+    template_name: vrf_static_route
+    nv_pairs:
+      IP_PREFIX: 192.168.7.1/32
+      NEXT_HOP_IP: 192.168.12.1
+      VRF_NAME: management

--- a/examples/policy_create.py
+++ b/examples/policy_create.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""
+# Name
+
+policy_create.py
+
+# Description
+
+Create a policy
+
+#Usage
+
+Edit ``examples/config/policy_create.yaml`` appropriately for your requirements.
+
+```yaml
+---
+config:
+  - switch_name: LE1
+    fabric_name: SITE1 # fabric_name needed to retrieve switch information
+    description: management vrf static route to syslog server
+    entity_name: SWITCH
+    entity_type: SWITCH
+    priority: 200
+    source: ""
+    template_name: vrf_static_route
+    nv_pairs:
+      IP_PREFIX: 192.168.7.1/32
+      NEXT_HOP_IP: 192.168.12.1
+      VRF_NAME: management
+```
+
+If you've set the standard ndfc-python Nexus Dashboard credentials
+environment variables (ND_DOMAIN, ND_IP4, ND_PASSWORD, ND_USERNAME)
+then you're good to go.
+
+```bash
+./policy_create.py --config config/config_policy_create.yaml
+```
+
+If you haven't set the standard ndfc-python Nexus Dashboard credentials
+environment variables, you can override them like so:
+
+```bash
+./policy_create.py --config config/config_policy_create.yaml --nd-username admin --nd-password MyPassword --nd-domain local --nd-ip4 10.1.1.2
+"""
+# pylint: disable=duplicate-code
+import argparse
+import logging
+import sys
+
+from ndfc_python.ndfc_python_logger import NdfcPythonLogger
+from ndfc_python.ndfc_python_sender import NdfcPythonSender
+from ndfc_python.parsers.parser_ansible_vault import parser_ansible_vault
+from ndfc_python.parsers.parser_config import parser_config
+from ndfc_python.parsers.parser_loglevel import parser_loglevel
+from ndfc_python.parsers.parser_nd_domain import parser_nd_domain
+from ndfc_python.parsers.parser_nd_ip4 import parser_nd_ip4
+from ndfc_python.parsers.parser_nd_password import parser_nd_password
+from ndfc_python.parsers.parser_nd_username import parser_nd_username
+from ndfc_python.policy_create import PolicyCreate
+from ndfc_python.read_config import ReadConfig
+from ndfc_python.validators.policy_create import PolicyCreateConfig, PolicyCreateConfigValidator
+from plugins.module_utils.common.response_handler import ResponseHandler
+from plugins.module_utils.common.rest_send_v2 import RestSend
+from plugins.module_utils.common.results import Results
+from pydantic import ValidationError
+
+
+def action(cfg: PolicyCreateConfig) -> None:
+    """
+    Given a policy configuration, create the policy.
+    """
+    try:
+        instance = PolicyCreate()
+        instance.rest_send = rest_send
+        instance.results = Results()
+        instance.description = cfg.description
+        instance.fabric_name = cfg.fabric_name
+        instance.entity_name = cfg.entityName
+        instance.entity_type = cfg.entityType
+        instance.nv_pairs = cfg.nvPairs
+        instance.priority = cfg.priority
+        instance.source = cfg.source
+        instance.switch_name = cfg.switchName
+        instance.template_name = cfg.templateName
+        instance.template_content_type = cfg.templateContentType
+        instance.commit()
+    except (TypeError, ValueError) as error:
+        errmsg = "Error creating "
+        errmsg += f"fabric {cfg.fabric_name}, "
+        errmsg += f"switch {cfg.switchName}, "
+        errmsg += f"policy (template_name: {cfg.templateName}). "
+        errmsg += f"Error detail: {error}"
+        log.error(errmsg)
+        print(errmsg)
+        return
+
+    result_msg = "Created "
+    result_msg += f"fabric {instance.fabric_name}, "
+    result_msg += f"switch {instance.switch_name}, "
+    result_msg += f"policy_id {instance.rest_send.response_current.get('DATA', {}).get('policyId', 'N/A')}."
+    log.info(result_msg)
+    print(result_msg)
+
+
+def setup_parser() -> argparse.Namespace:
+    """
+    ### Summary
+
+    Setup script-specific parser
+
+    Returns:
+        argparse.Namespace
+    """
+    parser = argparse.ArgumentParser(
+        parents=[
+            parser_ansible_vault,
+            parser_config,
+            parser_loglevel,
+            parser_nd_domain,
+            parser_nd_ip4,
+            parser_nd_password,
+            parser_nd_username,
+        ],
+        description="DESCRIPTION: Create a vrf.",
+    )
+    return parser.parse_args()
+
+
+args = setup_parser()
+
+
+NdfcPythonLogger()
+log = logging.getLogger("ndfc_python.main")
+log.setLevel = args.loglevel
+
+try:
+    ndfc_config = ReadConfig()
+    ndfc_config.filename = args.config
+    ndfc_config.commit()
+except ValueError as error:
+    msg = f"Exiting: Error detail: {error}"
+    log.error(msg)
+    print(msg)
+    sys.exit()
+
+try:
+    validator = PolicyCreateConfigValidator(**ndfc_config.contents)
+except ValidationError as error:
+    msg = f"{error}"
+    log.error(msg)
+    print(msg)
+    sys.exit(1)
+
+try:
+    ndfc_sender = NdfcPythonSender()
+    ndfc_sender.args = args
+    ndfc_sender.commit()
+except ValueError as error:
+    msg = f"Exiting.  Error detail: {error}"
+    log.error(msg)
+    print(msg)
+    sys.exit(1)
+
+rest_send = RestSend({})
+rest_send.sender = ndfc_sender.sender
+rest_send.response_handler = ResponseHandler()
+rest_send.timeout = 2
+rest_send.send_interval = 5
+
+for item in validator.config:
+    action(item)

--- a/lib/ndfc_python/policy_create.py
+++ b/lib/ndfc_python/policy_create.py
@@ -1,0 +1,423 @@
+"""
+Name: ndfc_policy.py
+Description:
+
+Create ND policies
+"""
+
+# We use isort for import linting
+# pylint: disable=wrong-import-order
+import inspect
+import json
+import logging
+import sys
+
+from ndfc_python.common.fabric.fabric_inventory import FabricInventory
+from ndfc_python.common.fabric.fabrics_info import FabricsInfo
+from ndfc_python.common.properties import Properties
+from ndfc_python.switch_policy_info import SwitchPolicyInfo
+
+OUR_VERSION = 106
+
+
+class PolicyCreate:
+    """
+    create policies
+
+    Example create operation:
+
+    See `action()` in examples/policy_create.py
+    """
+
+    def __init__(self):
+        self.lib_version = OUR_VERSION
+        self.class_name = __class__.__name__
+        self.log = logging.getLogger(f"ndfc_python.{self.class_name}")
+
+        self._fabric_inventory_populated = False
+        self.switch_policies = []
+        self._switch_policies_populated = False
+        self._fabric_name = ""
+        self._nv_pairs = {}
+        self.fabric_inventory = FabricInventory()
+        self.fabrics_info = FabricsInfo()
+        self.properties = Properties()
+        self.switch_policy_info = SwitchPolicyInfo()
+
+        self._init_payload_set()
+        self._init_payload_set_mandatory()
+        self._init_payload_default()
+        self._init_payload_mapping_dict()
+        self._init_payload()
+
+        self._fabric_inventory_populated = False
+        self.rest_send = self.properties.rest_send
+
+    def _init_payload_set(self):
+        self._payload_set = set()
+        self._payload_set.add("description")
+        self._payload_set.add("entity_name")
+        self._payload_set.add("entity_type")
+        self._payload_set.add("ip_address")
+        self._payload_set.add("priority")
+        self._payload_set.add("serial_number")
+        self._payload_set.add("switch_name")
+        self._payload_set.add("source")
+        self._payload_set.add("template_name")
+        self._payload_set.add("template_content_type")
+
+    def _init_payload_set_mandatory(self):
+        self._payload_set_mandatory = set()
+        self._payload_set_mandatory.add("entity_name")
+        self._payload_set_mandatory.add("entity_type")
+        self._payload_set_mandatory.add("ip_address")
+        self._payload_set_mandatory.add("serial_number")
+        self._payload_set_mandatory.add("switch_name")
+
+    def _init_payload_default(self):
+        self._payload_default = {}
+        self._payload_default["source"] = ""
+        self._payload_default["template_content_type"] = "string"
+
+    def _init_payload(self):
+        self.payload = {}
+        for param in self._payload_set:
+            if param in self._payload_default:
+                value = self._payload_default[param]
+                self.payload[self._payload_mapping_dict[param]] = value
+            else:
+                self.payload[self._payload_mapping_dict[param]] = None
+
+    def _init_payload_mapping_dict(self):
+        """
+        see _map_payload_param()
+        """
+        self._payload_mapping_dict = {}
+        self._payload_mapping_dict["description"] = "description"
+        self._payload_mapping_dict["entity_name"] = "entityName"
+        self._payload_mapping_dict["entity_type"] = "entityType"
+        self._payload_mapping_dict["ip_address"] = "ipAddress"
+        self._payload_mapping_dict["nv_pairs"] = "nvPairs"
+        self._payload_mapping_dict["priority"] = "priority"
+        self._payload_mapping_dict["serial_number"] = "serialNumber"
+        self._payload_mapping_dict["source"] = "source"
+        self._payload_mapping_dict["switch_name"] = "switchName"
+        self._payload_mapping_dict["template_content_type"] = "templateContentType"
+        self._payload_mapping_dict["template_name"] = "templateName"
+
+    def _map_payload_param(self, param):
+        """
+        Because payload keys are camel case, and pylint does
+        not like camel case, we modified the corresponding
+        properties to be snake case.  This method maps the
+        camel case keys to their corresponding properties. It
+        is used in _final_verification to provide the user with
+        the correct property to call if there's a missing mandatory
+        payload property.
+        """
+        method_name = inspect.stack()[0][3]
+        if param not in self._payload_mapping_dict:
+            msg = f"{self.class_name}.{method_name}: "
+            msg += f"param {param} not in _payload_mapping_dict"
+            self.log.error(msg)
+            return param
+        return self._payload_mapping_dict[param]
+
+    def _build_payload(self) -> None:
+        """
+        build the payload from the current property values
+        """
+        method_name = inspect.stack()[0][3]
+        self.payload["description"] = self.description
+        self.payload["entityName"] = self.entity_name
+        self.payload["entityType"] = self.entity_type
+        self.payload["ipAddress"] = self.fabric_inventory.switch_name_to_ipv4_address(self.switch_name)
+        self.payload["nvPairs"] = self.nv_pairs
+        self.payload["priority"] = self.priority
+        self.payload["serialNumber"] = self.fabric_inventory.switch_name_to_serial_number(self.switch_name)
+        self.payload["source"] = self.source
+        self.payload["templateName"] = self.template_name
+        self.payload["templateContentType"] = self.template_content_type
+        msg = f"{self.class_name}.{method_name}: "
+        msg += f"payload: {json.dumps(self.payload, indent=4, sort_keys=True)}"
+        self.log.debug(msg)
+
+    def _final_verification(self):
+        """
+        final verification of all parameters
+        """
+        method_name = inspect.stack()[0][3]
+        if self.rest_send is None:
+            msg = f"{self.class_name}.{method_name}: "
+            msg += f"{self.class_name}.rest_send must be set before calling "
+            msg += f"{self.class_name}.commit"
+            raise ValueError(msg)
+
+        for param in self._payload_set_mandatory:
+            mapped_param = self._payload_mapping_dict[param]
+            if self.payload[mapped_param] == "":
+                msg = f"{self.class_name}.{method_name}: "
+                msg += f"exiting. call {self.class_name}.{self._map_payload_param(param)} "
+                msg += "before calling instance.create()"
+                self.log.error(msg)
+                sys.exit(1)
+
+        if self.fabric_exists() is False:
+            msg = f"{self.class_name}.{method_name}: "
+            msg += f"fabric_name {self.fabric_name} "
+            msg += "does not exist on the controller."
+            raise ValueError(msg)
+
+        if not self._fabric_inventory_populated:
+            self.populate_fabric_inventory()
+
+    def commit(self):
+        """
+        Create a policy
+        """
+        method_name = inspect.stack()[0][3]
+
+        self._final_verification()
+        self._populate_switch_policies()
+        self._validate_no_policy_name_conflict()
+        self._build_payload()
+
+        path = "/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/policies"
+        verb = "POST"
+
+        try:
+            self.rest_send.path = path
+            self.rest_send.verb = verb
+            self.rest_send.payload = self.payload
+            self.rest_send.commit()
+        except (TypeError, ValueError) as error:
+            msg = f"{self.class_name}.{method_name}: "
+            msg += f"Unable to send {self.rest_send.verb} request to the controller. "
+            msg += f"Error details: {error}"
+            raise ValueError(msg) from error
+
+        msg = f"{self.class_name}.{method_name}: "
+        msg += f"Sent {self.rest_send.verb} request to {self.rest_send.path}. "
+        msg += f"Response: {self.rest_send.response_current}"
+        self.log.debug(msg)
+        if self.rest_send.result_current.get("success") is False:
+            msg = f"{self.class_name}.{method_name}: "
+            msg += "Request unsuccessful. "
+            msg += f"{self.rest_send.result_current}. "
+            msg += "More detail (if any): "
+            msg += f"{self.rest_send.response_current.get('DATA', {}).get('error')}"
+            raise ValueError(msg)
+
+    def fabric_exists(self) -> bool:
+        """
+        Return True if self.fabric_name exists on the controller.
+        Return False otherwise.
+        """
+        self.fabrics_info.rest_send = self.rest_send
+        self.fabrics_info.commit()
+        self.fabrics_info.filter = self.fabric_name
+        return self.fabrics_info.fabric_exists
+
+    def _validate_no_policy_name_conflict(self) -> None:
+        """
+        # Summary
+
+        Validate that the policy description does not already exist on switch_name.
+
+        Validation is performed using description (which must be unique per switch)
+
+        ## Raises
+
+        - ValueError: if the policy already exists on the switch
+
+        """
+        method_name = inspect.stack()[0][3]
+        for policy in self.switch_policies:
+            if policy.get("description") == self.description:
+                policy_id = policy.get("policyId", "N/A")
+                msg = f"{self.class_name}.{method_name}: "
+                msg += f"Policy ID {policy_id} with description '{self.description}' already exists on switch {self.switch_name} "
+                msg += f"in fabric {self.fabric_name}. "
+                msg += "Use a unique policy description or delete the existing policy."
+                raise ValueError(msg)
+
+    def _populate_switch_policies(self) -> None:
+        """
+        # Summary
+
+        Populate switch policies for switch_name.
+
+        ## Raises
+
+        - ValueError: if FabricInventory raises
+
+        """
+        method_name = inspect.stack()[0][3]
+        if not self._fabric_inventory_populated:
+            self.populate_fabric_inventory()
+
+        self.switch_policy_info.rest_send = self.rest_send
+        self.switch_policy_info.fabric_name = self.fabric_name
+        self.switch_policy_info.switch_name = self.switch_name
+        try:
+            self.switch_policy_info.commit()
+        except ValueError as error:
+            msg = f"{self.class_name}.{method_name}: "
+            msg += f"Unable to populate switch policies for switch {self.switch_name} "
+            msg += f"in fabric {self.fabric_name}. "
+            msg += f"Error details: {error}"
+            raise ValueError(msg) from error
+
+        self.switch_policies = self.switch_policy_info.switch_policies
+        self._switch_policies_populated = True
+
+    def populate_fabric_inventory(self) -> None:
+        """
+        # Summary
+
+        Populate switch inventory for fabric_name.
+
+        ## Raises
+
+        - ValueError: if FabricInventory raises
+
+        """
+        method_name = inspect.stack()[0][3]
+        try:
+            self.fabric_inventory.fabric_name = self.fabric_name
+            self.fabric_inventory.rest_send = self.rest_send
+            self.fabric_inventory.commit()
+        except ValueError as error:
+            msg = f"{self.class_name}.{method_name}: "
+            msg += f"Unable to populate fabric inventory for fabric {self.fabric_name}. "
+            if self.fabric_inventory.return_code == 404:
+                msg += f"fabric_name {self.fabric_name} does not exist on the controller. "
+            else:
+                msg += f"Error details: {error}"
+            raise ValueError(msg) from error
+        self._fabric_inventory_populated = True
+
+    @property
+    def description(self):
+        """
+        The description of the policy.  Description is mandatory and MUST be unique.
+
+        Set (setter) or return (getter) the current payload value of description
+        """
+        return self.payload["description"]
+
+    @description.setter
+    def description(self, param):
+        self.payload["description"] = param
+
+    @property
+    def entity_name(self):
+        """
+        Set (setter) or return (getter) the current payload value of entity_name
+        """
+        return self.payload["entityName"]
+
+    @entity_name.setter
+    def entity_name(self, param):
+        self.payload["entityName"] = param
+
+    @property
+    def entity_type(self):
+        """
+        Set (setter) or return (getter) the current payload value of entity_type
+        """
+        return self.payload["entityType"]
+
+    @entity_type.setter
+    def entity_type(self, param):
+        self.payload["entityType"] = param
+
+    @property
+    def fabric_name(self) -> str:
+        """
+        Fabric in which the switch resides
+
+        Set (setter) or return (getter) the current value of fabric
+
+        NOTES:
+
+        1. fabric_name is required to populate the fabric inventory for switch_name to
+        ip_address and serial_number conversion, but is not included in the payload sent
+        to the controller.
+        """
+        return self._fabric_name
+
+    @fabric_name.setter
+    def fabric_name(self, value: str) -> None:
+        self._fabric_name = value
+
+    @property
+    def nv_pairs(self) -> dict:
+        """
+        Set (setter) or return (getter) the current value of nv_pairs
+        """
+        return self._nv_pairs
+
+    @nv_pairs.setter
+    def nv_pairs(self, param: dict) -> None:
+        if not isinstance(param, dict):
+            msg = f"exiting. expected dict(), got {param} with type "
+            msg += f"{type(param).__name__}"
+            self.log.error(msg)
+            sys.exit(1)
+        self._nv_pairs = param
+
+    @property
+    def switch_name(self):
+        """
+        Set (setter) or return (getter) the current payload value of switch_name
+        """
+        return self.payload["switchName"]
+
+    @switch_name.setter
+    def switch_name(self, param):
+        self.payload["switchName"] = param
+
+    @property
+    def template_content_type(self):
+        """
+        Set (setter) or return (getter) the current payload value of template_content_type
+        """
+        return self.payload["templateContentType"]
+
+    @template_content_type.setter
+    def template_content_type(self, param):
+        self.payload["templateContentType"] = param
+
+    @property
+    def template_name(self):
+        """
+        Set (setter) or return (getter) the current payload value of template_name
+        """
+        return self.payload["templateName"]
+
+    @template_name.setter
+    def template_name(self, param):
+        self.payload["templateName"] = param
+
+    @property
+    def priority(self):
+        """
+        Set (setter) or return (getter) the current payload value of priority
+        """
+        return self.payload["priority"]
+
+    @priority.setter
+    def priority(self, param):
+        self.payload["priority"] = param
+
+    @property
+    def source(self):
+        """
+        Set (setter) or return (getter) the current payload value of source
+        """
+        return self.payload["source"]
+
+    @source.setter
+    def source(self, param):
+        self.payload["source"] = param

--- a/lib/ndfc_python/switch_policy_info.py
+++ b/lib/ndfc_python/switch_policy_info.py
@@ -40,7 +40,6 @@ class SwitchPolicyInfoEndpoint:
         self.verb = "GET"
         self._commited = False
 
-
     def _final_verification(self) -> None:
         """
         final verification of all parameters

--- a/lib/ndfc_python/switch_policy_info.py
+++ b/lib/ndfc_python/switch_policy_info.py
@@ -1,0 +1,261 @@
+"""
+# Name
+
+switch_policy_info.py
+
+# Description
+
+Send GET request to the controller for switch policy information.
+
+# Endpoint
+
+Verb: GET
+Path: /appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/policies/switches?serialNumber=<serialNumber>
+
+"""
+
+# We are using isort for import sorting.
+# pylint: disable=wrong-import-order
+
+import inspect
+import logging
+
+from ndfc_python.common.fabric.fabric_inventory import FabricInventory
+from ndfc_python.common.fabric.fabrics_info import FabricsInfo
+from ndfc_python.common.properties import Properties
+
+
+class SwitchPolicyInfoEndpoint:
+    """
+    SwitchPolicyInfoEndpoint class to build the endpoint for the SwitchPolicyInfo API request
+    """
+
+    def __init__(self):
+        self.class_name = __class__.__name__
+        self.log = logging.getLogger(f"ndfc_python.{self.class_name}")
+
+        self.apiv1 = "/appcenter/cisco/ndfc/api/v1"
+        self._path = f"{self.apiv1}/lan-fabric/rest/control/policies/switches?serialNumber="
+        self.serial_number = ""
+        self.verb = "GET"
+        self._commited = False
+
+
+    def _final_verification(self) -> None:
+        """
+        final verification of all parameters
+        """
+        method_name = inspect.stack()[0][3]
+        if not self.serial_number:
+            msg = f"{self.class_name}.{method_name}: "
+            msg += f"{self.class_name}.serial_number must be set before calling "
+            msg += f"{self.class_name}.commit"
+            raise ValueError(msg)
+
+    def commit(self) -> None:
+        """
+        Build the endpoint path for the API request
+        """
+        self._path = f"{self._path}{self.serial_number}"
+        self._commited = True
+
+    @property
+    def path(self) -> str:
+        """
+        Return the endpoint path.
+
+        instance.commit() must be called before accessing this property.
+        """
+        method_name = inspect.stack()[0][3]
+        if not self._commited:
+            method_name = inspect.stack()[0][3]
+            msg = f"{self.class_name}.{method_name}: "
+            msg += f"{self.class_name}.commit() must be called before accessing "
+            msg += f"{self.class_name}.{method_name}"
+            raise ValueError(msg)
+        return self._path
+
+    @property
+    def serial_number(self) -> str:
+        """
+        return the current value of serial_number
+        """
+        return self._serial_number
+
+    @serial_number.setter
+    def serial_number(self, value: str) -> None:
+        self._serial_number = value
+
+
+class SwitchPolicyInfo:
+    """
+    # Summary
+
+    Get switch policy information
+
+    ## Example switch policy info request
+
+    ### See
+
+    ./examples/switch_policy_info.py
+    """
+
+    def __init__(self):
+        self.class_name = __class__.__name__
+        self.log = logging.getLogger(f"ndfc_python.{self.class_name}")
+
+        self.endpoint = SwitchPolicyInfoEndpoint()
+        self.fabric_inventory = FabricInventory()
+        self.fabrics_info = FabricsInfo()
+        self.properties = Properties()
+
+        self.rest_send = self.properties.rest_send
+        self._switch_policies = []
+        self._switch_policies_populated = False
+        self._fabric_inventory_populated = False
+
+        self._fabric_name = ""
+        self._network_name = ""
+
+    def _final_verification(self) -> None:
+        """
+        final verification of all parameters
+        """
+        method_name = inspect.stack()[0][3]
+        if self.rest_send is None:
+            msg = f"{self.class_name}.{method_name}: "
+            msg += f"{self.class_name}.rest_send must be set before calling "
+            msg += f"{self.class_name}.commit"
+            raise ValueError(msg)
+
+        if not self.fabric_name:
+            msg = f"{self.class_name}.{method_name}: "
+            msg += f"{self.class_name}.fabric_name must be set before calling "
+            msg += f"{self.class_name}.commit"
+            raise ValueError(msg)
+
+        if not self.switch_name:
+            msg = f"{self.class_name}.{method_name}: "
+            msg += f"{self.class_name}.switch_name must be set before calling "
+            msg += f"{self.class_name}.commit"
+            raise ValueError(msg)
+
+        if self.fabric_exists() is False:
+            msg = f"{self.class_name}.{method_name}: "
+            msg += f"fabric_name {self.fabric_name} "
+            msg += "does not exist on the controller."
+            raise ValueError(msg)
+
+        if not self._fabric_inventory_populated:
+            self.populate_fabric_inventory()
+
+        if self.switch_name not in self.fabric_inventory.devices:
+            msg = f"{self.class_name}.{method_name}: "
+            msg += f"switch_name {self.switch_name} not found in fabric {self.fabric_name}."
+            raise ValueError(msg)
+
+    def commit(self) -> None:
+        """
+        Retrieve switch policy information from the controller.
+        """
+        method_name = inspect.stack()[0][3]
+        self._final_verification()
+
+        self.endpoint.serial_number = self.fabric_inventory.switch_name_to_serial_number(self.switch_name)
+        self.endpoint.commit()
+        path = self.endpoint.path
+        verb = self.endpoint.verb
+
+        try:
+            self.rest_send.path = path
+            self.rest_send.verb = verb
+            self.rest_send.commit()
+        except (TypeError, ValueError) as error:
+            msg = f"{self.class_name}.{method_name}: "
+            msg += f"Unable to send {self.rest_send.verb} request to the controller. "
+            msg += f"Error details: {error}"
+            raise ValueError(msg) from error
+
+        self._populate_switch_policies()
+
+    def fabric_exists(self) -> bool:
+        """
+        Return True if self.fabric_name exists on the controller.
+        Return False otherwise.
+        """
+        self.fabrics_info.rest_send = self.rest_send
+        self.fabrics_info.commit()
+        self.fabrics_info.filter = self.fabric_name
+        return self.fabrics_info.fabric_exists
+
+    def populate_fabric_inventory(self) -> None:
+        """
+        Get switch inventory for a specific fabric.
+        """
+        try:
+            self.fabric_inventory.fabric_name = self.fabric_name
+            self.fabric_inventory.rest_send = self.rest_send
+            self.fabric_inventory.commit()
+        except ValueError as error:
+            msg = f"{self.class_name}.populate_fabric_inventory: "
+            msg += f"Unable to populate fabric inventory for fabric {self.fabric_name}. "
+            msg += f"Error details: {error}"
+            raise ValueError(msg) from error
+        self._fabric_inventory_populated = True
+
+    def _populate_switch_policies(self) -> None:
+        """
+        # Summary
+
+        Populate switch policies for switch_name.
+
+        ## Raises
+
+        - ValueError: if FabricInventory raises
+
+        """
+        method_name = inspect.stack()[0][3]
+        path = f"/appcenter/cisco/ndfc/api/v1/lan-fabric/rest/control/policies/switches?serialNumber={self.fabric_inventory.switch_name_to_serial_number(self.switch_name)}"
+        verb = "GET"
+        try:
+            self.rest_send.path = path
+            self.rest_send.verb = verb
+            self.rest_send.payload = None
+            self.rest_send.commit()
+            self._switch_policies = self.rest_send.response_current.get("DATA", [])
+        except ValueError as error:
+            msg = f"{self.class_name}.{method_name}: "
+            msg += f"Unable to populate switch policies for switch {self.switch_name} "
+            msg += f"in fabric {self.fabric_name}. "
+            msg += f"Error details: {error}"
+            raise ValueError(msg) from error
+        self._switch_policies_populated = True
+
+    @property
+    def fabric_name(self) -> str:
+        """
+        Set (setter) or return (getter) the current value of fabric_name
+        """
+        return self._fabric_name
+
+    @fabric_name.setter
+    def fabric_name(self, value: str) -> None:
+        self._fabric_name = value
+
+    @property
+    def switch_name(self) -> str:
+        """
+        Set (setter) or return (getter) the current value of switch_name
+        """
+        return self._switch_name
+
+    @switch_name.setter
+    def switch_name(self, value: str) -> None:
+        self._switch_name = value
+
+    @property
+    def switch_policies(self) -> str:
+        """
+        Return the current value of switch_policies
+        """
+        return self._switch_policies

--- a/lib/ndfc_python/validators/policy_create.py
+++ b/lib/ndfc_python/validators/policy_create.py
@@ -1,0 +1,30 @@
+from pydantic import BaseModel, Field
+
+
+class PolicyCreateConfig(BaseModel):
+    """
+    # Summary
+
+    Base validator for PolicyCreate arguments
+    """
+
+    description: str = Field(description="Mandatory description of the policy.  Description MUST be unique.")
+    entityName: str = Field(alias="entity_name")
+    entityType: str = Field(alias="entity_type")
+    fabric_name: str = Field(description="Required to retrieve switch information.  Not used in payload.")
+    nvPairs: dict = Field(alias="nv_pairs", default={}, description="Policy-specific key-value pairs.")
+    priority: int = Field(default=200)
+    source: str = Field(default="")
+    switchName: str = Field(alias="switch_name")
+    templateName: str = Field(alias="template_name", default="")
+    templateContentType: str = Field(alias="template_content_type", default="string")
+
+
+class PolicyCreateConfigValidator(BaseModel):
+    """
+    # Summary
+
+    config is a list of PolicyCreateConfig
+    """
+
+    config: list[PolicyCreateConfig]


### PR DESCRIPTION
PolicyCreate: initial commit

This commit introduces a new class PolicyCreate to create switch policies on the Nexus Dashboard controller.

1. lib/ndfc_python/validators/policy_create.py

Validator for configuration file associated with PolicyCreate operations.

2. lib/ndfc_python/switch_policy_info.py

Class for retrieving policies associated with switch_name.

3. lib/ndfc_python/policy_create.py

Class to create switch policies.

4. examples/policy_create.py

Example script demonstrating creation of a switch policy.

5. Example configuration files

- examples/config/s34/policy_create.yaml

Site-specific configuration file example.

- examples/config/policy_create.yaml

Generic configuration file example.